### PR TITLE
Remove padding from map.html for the purpose of embedding.

### DIFF
--- a/map.html
+++ b/map.html
@@ -23,7 +23,7 @@
       position: absolute;
       top:0; left:0; right:0; bottom:0;
       margin:0;
-      padding: 8px;
+      padding: 0px;
     }
     #map {
       margin:0; padding:0;


### PR DESCRIPTION
Embedders might want to remove padding, because it leads ugly white border, when background is not white.
