### PR TITLE
Add hyperlinks for Wikidata entries

### DIFF
--- a/js/overpass.js
+++ b/js/overpass.js
@@ -383,6 +383,11 @@ setTimeout(function() {
                   if (((wiki_lang = k.match(/^wikipedia\:(.*)$/)) && (wiki_page = v)) || 
                       ((k == "wikipedia") && (wiki_lang = v.match(/^([a-zA-Z]+)\:(.*)$/)) && (wiki_page = wiki_lang[2])))
                     v = '<a href="http://'+wiki_lang[1]+'.wikipedia.org/wiki/'+encodeURIComponent(wiki_page)+'" target="_blank">'+v+'</a>';
+                  // hyperlinks for wikidata entries
+                  var wikidata_page;
+                  if ((wikidata_page = v)) ||
+                      ((k == "wikidata") && (wikidata_page = v.match(Q[1-9]*)
+                    v = '<a href="https://www.wikidata.org/wiki/'+encodeURIComponent(wikidata_page)+'" target="_blank">'+v+'</a>';
                   popup += "<li>"+k+"="+v+"</li>"
                 });
                 popup += "</ul>";


### PR DESCRIPTION
This will hopefully convert Wikidata tags into hyperlinks to wikidata.org.

For example, It should map the OSM tag 'wikidata=Q19777' to 'https://www.wikidata.org/wiki/Q19777', this could be seen [here](http://overpass-turbo.eu/s/2Hl)

I don't speak javascript, I just adapted the code to generate Wikipedia links and I haven't tested this, so please excuse me if I'm way off.
