### PR TITLE
Improve code/map display in portrait mode

### DIFF
--- a/css/default.css
+++ b/css/default.css
@@ -11,11 +11,11 @@ body {
   background-color: #FFFFFF;
   padding: 0;
   margin: 0;
-  height: auto!important;
+  height: auto;
   position:absolute;
-  top:51px !important;
-  bottom:0 !important;
-  left:0 !important;
+  top:51px;
+  bottom:0 ;
+  left:0 ;
   width:45%;
 }
 #dataviewer {
@@ -23,13 +23,29 @@ body {
   padding: 0;
   margin: 0;
   border-left:1px solid #ccc;
-  height: auto !important;
+  height: auto;
   position:absolute;
-  top:51px !important;
-  bottom:0 !important;
+  top:51px;
+  bottom:0;
   left:45%;
-  right:0 !important;
+  right:0;
 }
+
+#editor.portrait {
+  height: 25%;
+  width: 100%;
+  bottom: auto;
+}
+#dataviewer.portrait {
+  width: 100%;
+  padding: 0;
+  top: 30%;
+  top: calc(51px + 25%);
+  left: 0;
+  border-left: none;
+  border-top: 1px solid #ccc;
+}
+
 #map {
   width:100%;
   height:100%;

--- a/js/ide.js
+++ b/js/ide.js
@@ -129,19 +129,29 @@ var ide = new(function() {
 
     ide.waiter.addInfo("initialize page");
     // init page layout
-    if (settings.editor_width != "") {
+    var isInitialAspectPortrait = $(window).width() / $(window).height() < 0.75;
+    if (settings.editor_width != "" && !isInitialAspectPortrait) {
       $("#editor").css("width",settings.editor_width);
       $("#dataviewer").css("left",settings.editor_width);
     }
+    if (isInitialAspectPortrait) {
+      $("#editor, #dataviewer").addClass('portrait');
+    }
     // make panels resizable
     $("#editor").resizable({
-      handles:"e",
-      minWidth:"200",
-      resize: function() {
-        $(this).next().css('left', $(this).outerWidth() + 'px');
+      handles: isInitialAspectPortrait ? "s" : "e",
+      minWidth: isInitialAspectPortrait ? undefined : "200",
+      resize: function(ev) {
+        if (!isInitialAspectPortrait) {
+          $(this).next().css('left', $(this).outerWidth() + 'px');
+        } else {
+          var top = $(this).offset().top + $(this).outerHeight();
+          $(this).next().css('top', top + 'px');
+        }
         ide.map.invalidateSize(false);
       },
       stop:function() {
+        if (isInitialAspectPortrait) return;
         settings.editor_width = $("#editor").css("width");
         settings.save();
       }


### PR DESCRIPTION
For rotated monitors (1200x1920) this positions the code editor above the map.

[Before](https://cloud.githubusercontent.com/assets/782446/12689905/052a07e0-c6e0-11e5-9556-31f06c8a8535.png) – [After](https://cloud.githubusercontent.com/assets/782446/12689912/1252ff62-c6e0-11e5-82ee-4eb944d4bc1e.png)
