### PR TITLE
fix togpx call in ide to generate valid gpx

### DIFF
--- a/js/ide.js
+++ b/js/ide.js
@@ -1898,8 +1898,8 @@ var ide = new function() {
           gpx_str = togpx(geojson, {
             creator: configs.appname,
             metadata: {
-              copyright: overpass.copyright,
               desc: "Filtered OSM data converted to GPX by overpass turbo",
+              copyright: {"@author": overpass.copyright},
               time: overpass.timestamp
             },
             featureTitle: function(props) {


### PR DESCRIPTION
The currently generated GPX files are invalid. Most programs don't care, but for example Garmin BaseCamp (4.6.3) fails to open the files.

Invalidity comes from two points: incorrectly constructed `copyright` tag and wrong order of tags in the `metadata` part of the gpx file. This one-line change in the code fixes both (the order of the values in the dictionary passed to the `togpx` function seems to be maintained even though this is not guaranteed by design). 

Full error list when running validation of current gpx at [https://www.xmlvalidation.com/](https://www.xmlvalidation.com/):

 line | chr | error
 -- | -- | --
 2: | 257 | cvc-complex-type.4: Attribute 'author' must appear on element 'copyright'.
 2: | 373 | cvc-complex-type.2.3: Element 'copyright' cannot have character [children], because the type's content type is element-only.
 2: | 379 | cvc-complex-type.2.4.a: Invalid content was found starting with element 'desc'. One of '{"http://www.topografix.com/GPX/1/1":link, "http://www.topografix.com/GPX/1/1":time, "http://www.topografix.com/GPX/1/1":keywords, "http://www.topografix.com/GPX/1/1":bounds, "http://www.topografix.com/GPX/1/1":extensions}' is expected.

