### PR TITLE
Update rambler URL

### DIFF
--- a/js/configs.js
+++ b/js/configs.js
@@ -4,7 +4,7 @@ export default {
   suggestedServers: [
     "//overpass-api.de/api/",
     "https://overpass.kumi.systems/api/",
-    "http://overpass.osm.rambler.ru/cgi/",
+    "http://overpass.openstreetmap.ru/cgi/",
     "//overpass.openstreetmap.fr/api/"
   ],
   defaultTiles: "//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",


### PR DESCRIPTION
Rambler has asked for all OSM projects to be moved from its subdomain. So [we are moving them](https://wiki.openstreetmap.org/w/index.php?title=OSM_Servers_in_Rambler&type=revision&diff=1597546&oldid=1438375), including the Overpass API server. This pull request updates the URL.

Make sure to update it in your local config.