### PR TITLE
Display tag count in the popup

### DIFF
--- a/js/overpass.js
+++ b/js/overpass.js
@@ -672,7 +672,11 @@ var overpass = new function() {
                         feature.properties.tags &&
                         !$.isEmptyObject(feature.properties.tags)
                       ) {
-                        popup += '<h3>Tags:</h3><ul class="plain">';
+                        popup += '<h3>Tags';
+                        if(typeof Object.keys === 'function'){
+                          popup += ' (' + Object.keys(feature.properties.tags).length + ')';
+                        }
+                        popup += ':</h3><ul class="plain">';
                         $.each(feature.properties.tags, function(k, v) {
                           k = htmlentities(k); // escaping strings!
                           v = htmlentities(v);


### PR DESCRIPTION
This is a quick solution for the tag count in the popup.
![image](https://user-images.githubusercontent.com/2410353/39325482-9761d6c4-4992-11e8-9703-5cd29e5afd30.png)

I am lazy and use `Object.keys(tagObj).length`. 
Object.keys was first [available in IE9](https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Object/keys). 
I use a feature detection so IE8 would not show the tag count (but does not crash).

fixes #376 