### PR TITLE
umap export

### DIFF
--- a/index.html
+++ b/index.html
@@ -202,32 +202,15 @@
     <p class="t" data-t="[html]export.generic_download_copy" id="export-text"></p>
     <p class="t" data-t="[html]export.generic_download_copy" id="export-text_raw"></p>
     <p class="t" data-t="[html]export.generic_download_copy" id="export-text_wiki"></p>
+    <p class="t" data-t="[html]export.generic_download_copy" id="export-text_umap"></p>
     <p class="t" data-t="[html]export.to_xml"></p>
     <p class="t" data-t="[html]export.to_ql"></p>
     </div>
   </div>
-  <div title="" id="export-geojson-dialog" class="t dialog" data-t="[title]export.geoJSON.title">
+  <div title="" id="export-download-dialog" class="t dialog" data-t="[title]export.download-error">
     <p class="message"></p>
   </div>
-  <div title="" id="export-gpx-dialog" class="t dialog" data-t="[title]export.GPX.title">
-    <p class="message"></p>
-  </div>
-  <div title="" id="export-kml-dialog" class="t dialog" data-t="[title]export.KML.title">
-    <p class="message"></p>
-  </div>
-  <div title="" id="export-raw-dialog" class="t dialog" data-t="[title]export.raw.title">
-    <p class="message"></p>
-  </div>
-  <div title="" id="export-ql-placeholder-dialog" class="t dialog" data-t="[title]export.to_ql_placeholder_query_title">
-    <p class="message"></p>
-  </div>
-  <div title="" id="export-standalone-query-dialog" class="t dialog" data-t="[title]export.standalone_query_title">
-    <p class="message"></p>
-  </div>
-  <div title="" id="export-raw-query-dialog" class="t dialog" data-t="[title]export.raw_query_title">
-    <p class="message"></p>
-  </div>
-  <div title="" id="export-osm-wiki-query-dialog" class="t dialog" data-t="[title]export.osm_wiki_query_title">
+  <div title="" id="export-clipboard-success" class="t dialog" data-t="[title]export.copy_to_clipboard_success">
     <p class="message"></p>
   </div>
   <!--share-->

--- a/index.html
+++ b/index.html
@@ -218,7 +218,16 @@
   <div title="" id="export-raw-dialog" class="t dialog" data-t="[title]export.raw.title">
     <p class="message"></p>
   </div>
-  <div title="" id="export-ql-placeholder" class="t dialog" data-t="[title]export.to_ql_placeholder_title">
+  <div title="" id="export-ql-placeholder-dialog" class="t dialog" data-t="[title]export.to_ql_placeholder_query_title">
+    <p class="message"></p>
+  </div>
+  <div title="" id="export-standalone-query-dialog" class="t dialog" data-t="[title]export.standalone_query_title">
+    <p class="message"></p>
+  </div>
+  <div title="" id="export-raw-query-dialog" class="t dialog" data-t="[title]export.raw_query_title">
+    <p class="message"></p>
+  </div>
+  <div title="" id="export-osm-wiki-query-dialog" class="t dialog" data-t="[title]export.osm_wiki_query_title">
     <p class="message"></p>
   </div>
   <!--share-->

--- a/index.html
+++ b/index.html
@@ -218,6 +218,9 @@
   <div title="" id="export-raw-dialog" class="t dialog" data-t="[title]export.raw.title">
     <p class="message"></p>
   </div>
+  <div title="" id="export-ql-placeholder" class="t dialog" data-t="[title]export.to_ql_placeholder_title">
+    <p class="message"></p>
+  </div>
   <!--share-->
   <div title="" id="share-dialog" class="t dialog" data-t="[title]share.title">
     <h3 class="t" data-t="share.header"></h3>

--- a/js/ide.js
+++ b/js/ide.js
@@ -2127,6 +2127,29 @@ var ide = new function() {
         encodeURIComponent(query) +
         "&target=compact";
 
+      function constructOverpassQLUrl(query) {
+        // remove /* */ comments from query
+        query = query.replace(/\/\*(.|\n)*?\*\//g, "");
+        // replace bbox with south west north east
+        query = query.replace(/{{bbox}}/g, "{south},{west},{north},{east}");
+        // replace //  comments from query
+        query = query.replace(/\/\/.*/g, "");
+        // removes indentation
+        query = query.replace(/\n(\s|\t)+/g, "");
+        query = query.replace(/\n/g, "");
+        return "https:" + server + "interpreter?data=" + query;
+      }
+      $("#export-dialog a#export-convert-compact-placeholder")
+        .attr("href", "")
+        .click(function() {
+          var raw_query = ide.getRawQuery();
+          copyData = {
+            "text/plain": constructOverpassQLUrl(raw_query)
+          };
+          document.execCommand("copy");
+          return false;
+        });
+
       // OSM editors
       // first check for possible mistakes in query.
       var validEditorQuery = Autorepair.detect.editors(

--- a/js/ide.js
+++ b/js/ide.js
@@ -1601,12 +1601,25 @@ var ide = new function() {
           Base64.encode(text, true)
         );
       }
-      function copyHandler(text) {
+      function copyHandler(text, selector) {
         return function() {
+          // selector
+          var d = selector;
+          d = $("#" + d);
           copyData = {
             "text/plain": text
           };
+          var dialog_buttons = {};
+          dialog_buttons[i18n.t("dialog.dismiss")] = function() {
+            $(this).dialog("close");
+          };
+          d.dialog({
+            modal: true,
+            width: 500,
+            buttons: dialog_buttons
+          });
           document.execCommand("copy");
+          $(".message", d).text("Copied to clipboard.");
           return false;
         };
       }
@@ -1619,7 +1632,7 @@ var ide = new function() {
       });
       $("#export-text .copy")
         .attr("href", "")
-        .click(copyHandler(query));
+        .click(copyHandler(query, "export-standalone-query-dialog"));
       // export raw query
       var query_raw = ide.getRawQuery();
       $("#export-text_raw .format").html(i18n.t("export.format_text_raw"));
@@ -1630,7 +1643,7 @@ var ide = new function() {
       });
       $("#export-text_raw .copy")
         .attr("href", "")
-        .click(copyHandler(query_raw));
+        .click(copyHandler(query_raw, "export-raw-query-dialog"));
       // export wiki query
       var query_wiki =
         "{{OverpassTurboExample|loc=" +
@@ -1660,8 +1673,7 @@ var ide = new function() {
       });
       $("#export-text_wiki .copy")
         .attr("href", "")
-        .click(copyHandler(query_wiki));
-
+        .click(copyHandler(query_wiki, "export-osm-wiki-query-dialog"));
       var dialog_buttons = {};
       dialog_buttons[i18n.t("dialog.done")] = function() {
         $(this).dialog("close");
@@ -1825,6 +1837,16 @@ var ide = new function() {
       $("#export-geoJSON .copy")
         .attr("href", "")
         .click(function() {
+          var d = $("#export-geojson-dialog");
+          var dialog_buttons = {};
+          dialog_buttons[i18n.t("dialog.dismiss")] = function() {
+            $(this).dialog("close");
+          };
+          d.dialog({
+            modal: true,
+            width: 500,
+            buttons: dialog_buttons
+          });
           if (overpass.geojson) {
             var geojson = constructGeojsonString(overpass.geojson);
             copyData = {
@@ -1832,6 +1854,11 @@ var ide = new function() {
               "application/geo+json": geojson
             };
             document.execCommand("copy");
+            $(".message", d).text("Copied to clipboard.");
+          } else {
+            $(".message", d).text(
+              "No GeoJSON data available! Please run a query first."
+            );
           }
           return false;
         });
@@ -1956,6 +1983,16 @@ var ide = new function() {
       $("#export-GPX .copy")
         .attr("href", "")
         .click(function() {
+          var d = $("#export-gpx-dialog");
+          var dialog_buttons = {};
+          dialog_buttons[i18n.t("dialog.dismiss")] = function() {
+            $(this).dialog("close");
+          };
+          d.dialog({
+            modal: true,
+            width: 500,
+            buttons: dialog_buttons
+          });
           if (overpass.geojson) {
             var gpx = constructGpxString(overpass.geojson);
             copyData = {
@@ -1963,6 +2000,11 @@ var ide = new function() {
               "application/gpx+xml": gpx
             };
             document.execCommand("copy");
+            $(".message", d).text("Copied to clipboard.");
+          } else {
+            $(".message", d).text(
+              "No GeoJSON data available! Please run a query first."
+            );
           }
           return false;
         });
@@ -2016,6 +2058,16 @@ var ide = new function() {
       $("#export-KML .copy")
         .attr("href", "")
         .click(function() {
+          var d = $("#export-kml-dialog");
+          var dialog_buttons = {};
+          dialog_buttons[i18n.t("dialog.dismiss")] = function() {
+            $(this).dialog("close");
+          };
+          d.dialog({
+            modal: true,
+            width: 500,
+            buttons: dialog_buttons
+          });
           if (overpass.geojson) {
             var kml = constructKmlString(overpass.geojson);
             copyData = {
@@ -2023,6 +2075,11 @@ var ide = new function() {
               "application/vnd.google-earth.kml+xml": kml
             };
             document.execCommand("copy");
+            $(".message", d).text("Copied to clipboard.");
+          } else {
+            $(".message", d).text(
+              "No GeoJSON data available! Please run a query first."
+            );
           }
           return false;
         });
@@ -2097,6 +2154,16 @@ var ide = new function() {
       $("#export-raw .copy")
         .attr("href", "")
         .click(function() {
+          var d = $("#export-raw-dialog");
+          var dialog_buttons = {};
+          dialog_buttons[i18n.t("dialog.dismiss")] = function() {
+            $(this).dialog("close");
+          };
+          d.dialog({
+            modal: true,
+            width: 500,
+            buttons: dialog_buttons
+          });
           var geojson = overpass.geojson;
           if (geojson) {
             var raw = constructRawData(geojson);
@@ -2113,6 +2180,11 @@ var ide = new function() {
               copyData["application/octet-stream"] = raw_str;
             }
             document.execCommand("copy");
+            $(".message", d).text("Copied to clipboard.");
+          } else {
+            $(".message", d).text(
+              "No GeoJSON data available! Please run a query first."
+            );
           }
           return false;
         });
@@ -2140,15 +2212,12 @@ var ide = new function() {
       }
       $("#export-dialog a#export-convert-compact-placeholder")
         .attr("href", "")
-        .click(function() {
-          var raw_query = ide.getRawQuery();
-          copyData = {
-            "text/plain": constructOverpassQLUrl(raw_query)
-          };
-          document.execCommand("copy");
-          return false;
-        });
-
+        .click(
+          copyHandler(
+            constructOverpassQLUrl(ide.getRawQuery()),
+            "export-ql-placeholder-dialog"
+          )
+        );
       // OSM editors
       // first check for possible mistakes in query.
       var validEditorQuery = Autorepair.detect.editors(

--- a/js/ide.js
+++ b/js/ide.js
@@ -2129,14 +2129,13 @@ var ide = new function() {
 
       function constructOverpassQLUrl(query) {
         // remove /* */ comments from query
-        query = query.replace(/\/\*(.|\n)*?\*\//g, "");
+        query = query.replace(/\/\*[\S\s]*?\*\//g, "");
         // replace bbox with south west north east
         query = query.replace(/{{bbox}}/g, "{south},{west},{north},{east}");
         // replace //  comments from query
         query = query.replace(/\/\/.*/g, "");
         // removes indentation
-        query = query.replace(/\n(\s|\t)+/g, "");
-        query = query.replace(/\n/g, "");
+        query = query.replace(/\n\s*/g, "");
         return "https:" + server + "interpreter?data=" + query;
       }
       $("#export-dialog a#export-convert-compact-placeholder")

--- a/locales/en.json
+++ b/locales/en.json
@@ -96,7 +96,6 @@
   "export.to_ql": "convert to <a id=\"export-convert-ql\" href=\"\" target=\"_blank\" class=\"external\">OverpassQL </a> </br> &nbsp; &nbsp;<a id=\"export-convert-compact\" href=\"\" target=\"_blank\" class=\"external\">compact</a>or with placeholders/<a id=\"export-convert-compact-placeholder\" title=\"copies OverpassQL url to clipboard\" href>copy</a>",
   "export.to_ql_placeholder_title": "Export - OverpassQL with placeholders",
 
-
   "export.editors": "load data into an OSM editor:",
 
   "export.geoJSON.title": "Export - GeoJSON",

--- a/locales/en.json
+++ b/locales/en.json
@@ -93,7 +93,10 @@
   "export.format_text_raw": "<abbr title=\"Unaltered overpass turbo query – just as in the code editor\">raw query</abbr>",
   "export.format_text_wiki": "<abbr title=\"For usage in the OSM wiki as a OverpassTurboExample-Template\">osm wiki</abbr>",
   "export.to_xml": "convert to <a id=\"export-convert-xml\" href=\"\" target=\"_blank\" class=\"external\">Overpass-XML</a>",
-  "export.to_ql": "convert to (<a id=\"export-convert-compact\" href=\"\" target=\"_blank\" class=\"external\">compact</a>) <a id=\"export-convert-ql\" href=\"\" target=\"_blank\" class=\"external\">OverpassQL</a>",
+  "export.to_ql": "convert to <a id=\"export-convert-ql\" href=\"\" target=\"_blank\" class=\"external\">OverpassQL </a> </br> &nbsp; &nbsp;<a id=\"export-convert-compact\" href=\"\" target=\"_blank\" class=\"external\">compact</a>or with placeholders/<a id=\"export-convert-compact-placeholder\" title=\"copies OverpassQL url to clipboard\" href>copy</a>",
+  "export.to_ql_placeholder_title": "Export - OverpassQL with placeholders",
+
+
   "export.editors": "load data into an OSM editor:",
 
   "export.geoJSON.title": "Export - GeoJSON",

--- a/locales/en.json
+++ b/locales/en.json
@@ -93,8 +93,11 @@
   "export.format_text_raw": "<abbr title=\"Unaltered overpass turbo query – just as in the code editor\">raw query</abbr>",
   "export.format_text_wiki": "<abbr title=\"For usage in the OSM wiki as a OverpassTurboExample-Template\">osm wiki</abbr>",
   "export.to_xml": "convert to <a id=\"export-convert-xml\" href=\"\" target=\"_blank\" class=\"external\">Overpass-XML</a>",
-  "export.to_ql": "convert to <a id=\"export-convert-ql\" href=\"\" target=\"_blank\" class=\"external\">OverpassQL </a> </br> &nbsp; &nbsp;<a id=\"export-convert-compact\" href=\"\" target=\"_blank\" class=\"external\">compact</a>or with placeholders/<a id=\"export-convert-compact-placeholder\" title=\"copies OverpassQL url to clipboard\" href>copy</a>",
-  "export.to_ql_placeholder_title": "Export - OverpassQL with placeholders",
+  "export.to_ql": "convert to <a id=\"export-convert-ql\" href=\"\" target=\"_blank\" class=\"external\">OverpassQL </a> </br> &nbsp; &nbsp;<a id=\"export-convert-compact\" href=\"\" target=\"_blank\" class=\"external\">compact</a>or with placeholders/<a id=\"export-convert-compact-placeholder\" title=\"copies export output to clipboard\">copy</a>",
+  "export.to_ql_placeholder_query_title": "Export - OverpassQL with placeholders",
+  "export.standalone_query_title": "Export - Standalone Query",
+  "export.osm_wiki_query_title": "Export - Osm Wiki",
+  "export.raw_query_title": "Export - Raw Query",
 
   "export.editors": "load data into an OSM editor:",
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -74,7 +74,10 @@
   "load.no_saved_query": "no saved query yet",
 
   "export.title": "Export",
+  "export.download-error": "Export - Error",
   "export.copy_to_clipboard": "Copy this text to clipbard",
+  "export.copy_to_clipboard_success": "Export - Successfully copied to clipboard",
+  "export.copy_to_clipboard_success-message": "<span class=\"export-copy_to_clipboard-content\"></span> was successfully copied to the clipboard.",
 
   "export.section.map": "Map",
   "export.as_png": "as <a id=\"export-image\" href=\"\">png image</a>",
@@ -92,12 +95,9 @@
   "export.format_text": "<abbr title=\"For direct use with the Overpass API, has expanded shortcuts and doesn't include additional overpass turbo features such as MapCSS.\">standalone query</abbr>",
   "export.format_text_raw": "<abbr title=\"Unaltered overpass turbo query – just as in the code editor\">raw query</abbr>",
   "export.format_text_wiki": "<abbr title=\"For usage in the OSM wiki as a OverpassTurboExample-Template\">osm wiki</abbr>",
+  "export.format_text_umap": "<abbr title=\"For usage with umap.openstreetmap.fr\">umap</abbr> remote data url",
   "export.to_xml": "convert to <a id=\"export-convert-xml\" href=\"\" target=\"_blank\" class=\"external\">Overpass-XML</a>",
-  "export.to_ql": "convert to <a id=\"export-convert-ql\" href=\"\" target=\"_blank\" class=\"external\">OverpassQL </a> </br> &nbsp; &nbsp;<a id=\"export-convert-compact\" href=\"\" target=\"_blank\" class=\"external\">compact</a>or with placeholders/<a id=\"export-convert-compact-placeholder\" title=\"copies export output to clipboard\">copy</a>",
-  "export.to_ql_placeholder_query_title": "Export - OverpassQL with placeholders",
-  "export.standalone_query_title": "Export - Standalone Query",
-  "export.osm_wiki_query_title": "Export - Osm Wiki",
-  "export.raw_query_title": "Export - Raw Query",
+  "export.to_ql": "convert to <a id=\"export-convert-ql\" href=\"\" target=\"_blank\" class=\"external\">OverpassQL </a> </br> &nbsp; &nbsp;<a id=\"export-convert-compact\" href=\"\" target=\"_blank\" class=\"external\">compact</a>",
 
   "export.editors": "load data into an OSM editor:",
 


### PR DESCRIPTION
superseeds #399 and #400. additionally: 

* makes export option "query for use as _umap remote data url_" more explicit (separate line in export -> query dialog)
* refactors code a bit to slightly reduce duplication (no duplicate error/success dialogs for the different export options)
* (minor) better use of some already translated strings