### PR TITLE
added support for WPDA links

### DIFF
--- a/js/overpass.js
+++ b/js/overpass.js
@@ -771,6 +771,18 @@ var overpass = new function() {
                               '" target="_blank">' +
                               v +
                               "</a>";
+                          // hyperlinks for World Database of Protected Areas
+                          var wdpa_page;
+                          if (
+                            (k == "ref:WDPA" &&
+                              (wdpa_page = v.match(/^[0-9]+$/)))
+                          )
+                            v =
+                              '<a href="//protectedplanet.net/' +
+                              encodeURIComponent(wdpa_page[0]) +
+                              '" target="_blank">' +
+                              v +
+                              "</a>";
 
                           popup += "<li>" + k + "=" + v + "</li>";
                         });


### PR DESCRIPTION
requesting to add support for WPDA links.
Description in Wiki is not yet in line with the ref:.... standard but already available: https://wiki.openstreetmap.org/wiki/Key:WDPA_ID:ref

Links would open i.e. https://protectedplanet.net/5382

my JavaScript knowledge is very limited so not sure if I did everything correctly.