### PR TITLE
Always call JOSM over http

### DIFF
--- a/js/ide.js
+++ b/js/ide.js
@@ -2326,8 +2326,6 @@ var ide = new function() {
             .first();
           var send_to_josm = function(query) {
             var JRC_url = "http://127.0.0.1:8111/";
-            if (location.protocol === "https:")
-              JRC_url = "https://127.0.0.1:8112/";
             $.getJSON(JRC_url + "version")
               .done(function(d, s, xhr) {
                 if (d.protocolversion.major == 1) {


### PR DESCRIPTION
Https in JOSM is unreliable and will be dropped soon. See https://josm.openstreetmap.de/ticket/10033

All modern browsers support calling 127.0.0.1 over http even from https pages, per spec:

https://github.com/w3c/webappsec-mixed-content/commit/349501cdaa4b4dc1e2a8aacb216ced58fd316165
https://w3c.github.io/webappsec-secure-contexts/#is-origin-trustworthy

JOSM's default behaviour is to run without https.

Openstreetmap.org itself also always calls JOSM over http.