### PR TITLE
Fixing secure context detection

### DIFF
--- a/js/ide.js
+++ b/js/ide.js
@@ -554,10 +554,7 @@ var ide = new (function() {
         link.href = "#";
         link.className += " t";
         link.setAttribute("data-t", "[title]map_controlls.localize_user");
-        if (
-          location.protocol !== "https" &&
-          location.hostname !== "localhost"
-        ) {
+        if (!window.isSecureContext) {
           link.className += " disabled";
           link.setAttribute(
             "data-t",


### PR DESCRIPTION
`location.protocol` is `https:` and not `https` so the current code does not work as expected.

In any case it is better to use `window.isSecureContext` for this detection.
https://developer.mozilla.org/en-US/docs/Web/API/Window/isSecureContext