### PR TITLE
Travis: Build with Node LTS version only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
   - 7
   - 10
   - 13
-  - latest
+  - node # latest
 branches:
   except:
     - modularize

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 language: node_js
 node_js:
-  - 6
-  - 7
-  - 10
-  - 13
-  - node # latest
+  - lts
 branches:
   except:
     - modularize

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - lts
+  - lts/*
 branches:
   except:
     - modularize

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: node_js
 node_js:
   - 6
   - 7
+  - 10
+  - 13
+  - latest
 branches:
   except:
     - modularize


### PR DESCRIPTION
The current build only uses node 6 and 7, which are pretty old.

See https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#specifying-nodejs-versions for a list of node versions in Travis

Example build: https://travis-ci.org/github/tyrasd/overpass-turbo/builds/685284078