### PR TITLE
Add OpenHistoricalMap endpoint to settings

### DIFF
--- a/js/configs.js
+++ b/js/configs.js
@@ -5,7 +5,8 @@ export default {
     "//overpass-api.de/api/",
     "https://overpass.kumi.systems/api/",
     "http://overpass.openstreetmap.ru/cgi/",
-    "//overpass.openstreetmap.fr/api/"
+    "//overpass.openstreetmap.fr/api/",
+    "//overpass-api.openhistoricalmap.org/api/"
   ],
   defaultTiles: "//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
   tileServerAttribution:


### PR DESCRIPTION
[OpenHistoricalMap has its own Overpass API endpoint](https://wiki.openstreetmap.org/wiki/Open_Historical_Map#Using_the_data), which can apparently query for objects over all of history at the same time. 💪