### PR TITLE
Fix clicking an item while zoomed out

### DIFF
--- a/js/overpass.js
+++ b/js/overpass.js
@@ -891,6 +891,9 @@ var overpass = new (function () {
                       // node-ish features (circles, markers, icons, placeholders)
                       if (typeof e.target.getLatLng == "function")
                         latlng = e.target.getLatLng();
+                      // if there is a placeholder on a line, polygon or multipolygon
+                      // then get the center instead of the position of the click
+                      else if(e.target.placeholder) latlng = e.target.getBounds().getCenter();
                       else latlng = e.latlng; // all other (lines, polygons, multipolygons)
                       var p = L.popup({maxHeight: 600}, this)
                         .setLatLng(latlng)


### PR DESCRIPTION
currently if you click an item while zoomed out the circle is much bigger then the area itself,
if you click the circle on the edge and you zoom in the popup is no where near the selected area.
with this fix, if the item is a placeholder(circle) the popup will be placed in the center.