### PR TITLE
Default tile and overpass servers to https

### DIFF
--- a/js/configs.js
+++ b/js/configs.js
@@ -4,8 +4,7 @@ export default {
   suggestedServers: [
     "https://overpass-api.de/api/",
     "https://overpass.kumi.systems/api/",
-    "https://overpass.openstreetmap.ru/cgi/",
-    "https://overpass.openstreetmap.fr/api/"
+    "https://overpass.openstreetmap.ru/cgi/"
   ],
   defaultTiles: "//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
   tileServerAttribution:

--- a/js/configs.js
+++ b/js/configs.js
@@ -6,7 +6,7 @@ export default {
     "https://overpass.kumi.systems/api/",
     "https://overpass.openstreetmap.ru/cgi/"
   ],
-  defaultTiles: "//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+  defaultTiles: "https://tile.openstreetmap.org/{z}/{x}/{y}.png",
   tileServerAttribution:
     "&copy; OpenStreetMap.org contributors&ensp;<small>Data:ODbL, Map:cc-by-sa</small>",
   suggestedTiles: [

--- a/js/configs.js
+++ b/js/configs.js
@@ -1,17 +1,17 @@
 export default {
   appname: "overpass-turbo",
-  defaultServer: "//overpass-api.de/api/",
+  defaultServer: "https://overpass-api.de/api/",
   suggestedServers: [
-    "//overpass-api.de/api/",
+    "https://overpass-api.de/api/",
     "https://overpass.kumi.systems/api/",
-    "http://overpass.openstreetmap.ru/cgi/",
-    "//overpass.openstreetmap.fr/api/"
+    "https://overpass.openstreetmap.ru/cgi/",
+    "https://overpass.openstreetmap.fr/api/"
   ],
   defaultTiles: "//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
   tileServerAttribution:
     "&copy; OpenStreetMap.org contributors&ensp;<small>Data:ODbL, Map:cc-by-sa</small>",
   suggestedTiles: [
-    "//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+    "https://tile.openstreetmap.org/{z}/{x}/{y}.png"
     //"http://{s}.tile.opencyclemap.org/cycle/{z}/{x}/{y}.png",
     //"http://{s}.tile2.opencyclemap.org/transport/{z}/{x}/{y}.png",
     //"http://{s}.tile3.opencyclemap.org/landscape/{z}/{x}/{y}.png",


### PR DESCRIPTION
Modern https is a bit faster, and this avoids mixed content errors. Removing the {s} part of tile.openstreetmap.org makes tiles faster these days.

I've also removed the obsolete FR server (closes #562)