### PR TITLE
Set more expressive file extensions on download

### DIFF
--- a/js/ide.js
+++ b/js/ide.js
@@ -1662,7 +1662,7 @@ var ide = new (function () {
       // export query
       $("#export-text .format").html(i18n.t("export.format_text"));
       $("#export-text .export").attr({
-        download: "query.txt",
+        download: "query.overpassql",
         target: "_blank",
         href: toDataURL(query)
       });
@@ -1671,7 +1671,7 @@ var ide = new (function () {
       var query_raw = ide.getRawQuery();
       $("#export-text_raw .format").html(i18n.t("export.format_text_raw"));
       $("#export-text_raw .export").attr({
-        download: "query-raw.txt",
+        download: "query-raw.overpassql",
         target: "_blank",
         href: toDataURL(query_raw)
       });
@@ -1701,7 +1701,7 @@ var ide = new (function () {
       query_wiki += "\n}}";
       $("#export-text_wiki .format").html(i18n.t("export.format_text_wiki"));
       $("#export-text_wiki .export").attr({
-        download: "query-wiki.txt",
+        download: "query-wiki.mediawiki",
         target: "_blank",
         href: toDataURL(query_wiki)
       });
@@ -1723,7 +1723,7 @@ var ide = new (function () {
       );
       $("#export-text_umap .format").html(i18n.t("export.format_text_umap"));
       $("#export-text_umap .export").attr({
-        download: "query-umap.txt",
+        download: "query-umap.overpassql",
         target: "_blank",
         href: toDataURL(query_umap)
       });


### PR DESCRIPTION
Currently, when downloading the Overpass QL query as a file, it will always have the `.txt` file extension. This file extension will never provide syntax highlighting when editing in a modern text editor like VS Code, Sublime Text, Notepad++, etc.

This PR changes the file extension of the downloaded files:

* The *standalone query*, *raw query* and *umap remote data url* download options will now have the `.overpassql` file extension.  
  It was recently suggested as the [recommended file extension](https://wiki.openstreetmap.org/wiki/Overpass_API/Overpass_QL#File_extension) (*Disclaimer: I did that after some discussion.*) and is already [widely adopted](https://github.com/search?q=extension%3Aoverpassql), see also https://github.com/github/linguist/issues/5890.
* The *osm wiki* download option will now have the `.mediawiki` file extension.
  It is supported by all three ["MediaWiki" addons for VS Code](https://marketplace.visualstudio.com/search?term=mediawiki&target=VSCode&category=All%20categories&sortBy=Relevance) and probably others.