### PR TITLE
Fix crosshairs covered by Leaflet map pane

### DIFF
--- a/css/default.css
+++ b/css/default.css
@@ -244,6 +244,7 @@ a.ui-button:active,
   margin-top: -9px;
   margin-left: -8px;
   opacity: 0.6;
+  z-index: 800; /* Order above Leaflet map panes: https://leafletjs.com/reference.html#map-pane */
 }
 
 .errorline {


### PR DESCRIPTION
Set z-index of crosshairs element to order it above all Leaflet map panes.

Regressed in e4dffc41954c849d4483bddafc1daf0f087c498c.