### PR TITLE
Update readme and scripts to use yarn

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,6 @@ Development is done in the _master_ branch, stable releases are marked with git 
 
 ### install & run
 
-1. `npm install`
-2. `npm start` for a Development server listening at http://localhost:8080
-3. `npm run build` for a minified build in `./build`
+1. `yarn install`
+2. `yarn run start` for a Development server listening at http://localhost:5173
+3. `yarn run build` for a minified build in `./build`

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": "git+https://github.com/tyrasd/overpass-turbo.git",
   "license": "MIT",
   "scripts": {
-    "test": "npm run test:eslint && npm run test:style && npm run test:vitest",
+    "test": "yarn run test:eslint && yarn run test:style && yarn run test:vitest",
     "test:eslint": "eslint .",
     "test:style": "prettier --check .",
     "test:vitest": "vitest",


### PR DESCRIPTION
I assume you're supposed to use yarn given the yarn.lock file.

`yarn start` works as well but is undocumented.

Also fixed incorrect port number in readme.