### PR TITLE
Fix GHA perms, use workflow filter, add manual trigger

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,9 +1,16 @@
-name: Node.js CI
+name: Build & Deploy
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
 
 jobs:
   build:
+    permissions:
+      pages: write
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -13,9 +20,8 @@ jobs:
       - run: yarn install --no-progress --frozen-lockfile
       - run: yarn test
       - run: yarn build
-      - name: Deploy to https://tyrasd.github.io/overpass-turbo/
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+      - name: Deploy to https://${{ github.actor }}.github.io/${{ github.event.repository.name }}/
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./dist
+          publish_dir: dist


### PR DESCRIPTION
This reworks the Github action slightly to fix a permission issue when deploying to Github Pages from a brand new fork, as well as adding a manual trigger for the action so deployment to Pages can be triggered without pushing to the repo.

This also replaces the `if:` line with modern workflow filters, and generalises the logging.