### PR TITLE
Replaced spaces with underscores in Wikipedia section header

### DIFF
--- a/js/popup.ts
+++ b/js/popup.ts
@@ -69,6 +69,7 @@ export function featurePopupContent(feature: GeoJSON.Feature) {
           (wiki_lang = v.match(/^([a-zA-Z]+):(.*)$/)) &&
           (wiki_page = wiki_lang[2]))
       )
+        wiki_page = wiki_page.replace(/#.*$/, match => match.replace(/ /g, '_')); // 'Target page#Section header' -> 'Target page#Section_header'
         v = `<a href="//${wiki_lang[1]}.wikipedia.org/wiki/${wiki_page}" target="_blank">${v}</a>`;
       // hyperlinks for wikidata entries
       if (k.match(/(^|:)wikidata$/))


### PR DESCRIPTION
Query for examples:
`nwr["wikipedia"~"#.* "]({{bbox}});out;`

Wikipedia links in these nodes will redirect to page with an incorrect section header.
For example:
`https://en.wikipedia.org/wiki/Geography of France#Extreme points`

The correct link that will redirect to the appropriate section in the browser:
`https://en.wikipedia.org/wiki/Geography of France#Extreme_points`

This PR should fix it.