### PR TITLE
Add “Postpass” data source type for sql backends

### DIFF
--- a/js/OSM4Leaflet.ts
+++ b/js/OSM4Leaflet.ts
@@ -31,7 +31,7 @@ class OSM4Leaflet extends L.Layer {
   addData(data, onDone?: () => void) {
     setTimeout(() => {
       // 1. convert to GeoJSON
-      const geojson = osmtogeojson(data, {flatProperties: false});
+      const geojson = (this.options.query_lang == 'SQL') ? data : osmtogeojson(data, {flatProperties: false});
       this._resultData = geojson;
       if (this.options.afterParse) this.options.afterParse();
       setTimeout(() => {

--- a/js/OSM4Leaflet.ts
+++ b/js/OSM4Leaflet.ts
@@ -31,7 +31,11 @@ class OSM4Leaflet extends L.Layer {
   addData(data, onDone?: () => void) {
     setTimeout(() => {
       // 1. convert to GeoJSON
-      const geojson = (this.options.query_lang == 'SQL') ? data : osmtogeojson(data, {flatProperties: false});
+      const isGeoJSON =
+        typeof data === "object" && data?.type === "FeatureCollection";
+      const geojson = isGeoJSON
+        ? data
+        : osmtogeojson(data, {flatProperties: false});
       this._resultData = geojson;
       if (this.options.afterParse) this.options.afterParse();
       setTimeout(() => {

--- a/js/ide.ts
+++ b/js/ide.ts
@@ -1195,8 +1195,11 @@ class IDE {
     this.codeEditor.setValue(query);
   }
   getQueryLang() {
-    if ($.trim(this.getRawQuery().replace(/{{.*?}}/g, "")).match(/^</))
+    const q = $.trim(this.getRawQuery().replace(/{{.*?}}/g, ""))
+    if (q.match(/^</))
       return "xml";
+    else if (q.match(/planet_osm/i) && q.match(/select/i))
+      return "SQL";
     else return "OverpassQL";
   }
   /* this is for repairing obvious mistakes in the query, such as missing recurse statements */
@@ -1532,12 +1535,12 @@ class IDE {
     const baseurl = `${location.protocol}//${location.host}${
       location.pathname.match(/.*\//)[0]
     }`;
-    const server =
-      this.data_source &&
-      this.data_source.mode == "overpass" &&
-      this.data_source.options.server
-        ? this.data_source.options.server
-        : settings.server;
+    const query_lang = this.getQueryLang();
+    const server = (this.data_source &&
+      this.data_source.options.server &&
+      ((query_lang == "SQL" && this.data_source.mode == "sql") ||
+       this.data_source.mode == "overpass")) ? 
+          this.data_source.options.server : settings.server;
     let queryWithMapCSS = query;
     if (this.queryParser.hasStatement("style"))
       queryWithMapCSS += `{{style: ${this.queryParser.getStatement(
@@ -2719,12 +2722,12 @@ class IDE {
       }
     }
     const query_lang = this.getQueryLang();
-    const server =
-      this.data_source &&
-      this.data_source.mode == "overpass" &&
-      this.data_source.options.server
-        ? this.data_source.options.server
-        : settings.server;
+    const server = (this.data_source &&
+      this.data_source.options.server &&
+      ((query_lang == "SQL" && this.data_source.mode == "sql") ||
+       this.data_source.mode == "overpass")) ? 
+          this.data_source.options.server : settings.server;
+
     overpass.run_query(
       query,
       query_lang,

--- a/js/ide.ts
+++ b/js/ide.ts
@@ -2762,6 +2762,7 @@ class IDE {
       undefined,
       undefined,
       server,
+      this.data_source ? this.data_source.options : undefined,
       this.mapcss
     );
   }

--- a/js/ide.ts
+++ b/js/ide.ts
@@ -218,7 +218,7 @@ class IDE {
     abort() {
       if (typeof this.onAbort == "function") {
         this.addInfo("aborting");
-        this.onAbort(this.close);
+        this.onAbort(() => ide.waiter.close());
       }
     }
   })();

--- a/js/ide.ts
+++ b/js/ide.ts
@@ -1198,7 +1198,7 @@ class IDE {
     const q = $.trim(this.getRawQuery().replace(/{{.*?}}/g, ""))
     if (q.match(/^</))
       return "xml";
-    else if (q.match(/planet_osm/i) && q.match(/select/i))
+    else if (q.match(/^select/i))
       return "SQL";
     else return "OverpassQL";
   }

--- a/js/ide.ts
+++ b/js/ide.ts
@@ -1026,17 +1026,21 @@ class IDE {
       // display stats
       if (settings.show_data_stats) {
         const stats = overpass.stats;
-        const stats_txt =
-          `<small>${i18n.t("data_stats.loaded")}</small>&nbsp;&ndash;&nbsp;` +
-          `${i18n.t("data_stats.nodes")}:&nbsp;${stats.data.nodes}, ${i18n.t(
-            "data_stats.ways"
-          )}:&nbsp;${stats.data.ways}, ${i18n.t(
-            "data_stats.relations"
-          )}:&nbsp;${stats.data.relations}${
-            stats.data.areas > 0
-              ? `, ${i18n.t("data_stats.areas")}:&nbsp;${stats.data.areas}`
-              : ""
-          }<br/>` +
+        let stats_txt = "";
+        if (stats.data !== undefined) {
+          stats_txt +=
+            `<small>${i18n.t("data_stats.loaded")}</small>&nbsp;&ndash;&nbsp;` +
+            `${i18n.t("data_stats.nodes")}:&nbsp;${stats.data.nodes}, ${i18n.t(
+              "data_stats.ways"
+            )}:&nbsp;${stats.data.ways}, ${i18n.t(
+              "data_stats.relations"
+            )}:&nbsp;${stats.data.relations}${
+              stats.data.areas > 0
+                ? `, ${i18n.t("data_stats.areas")}:&nbsp;${stats.data.areas}`
+                : ""
+            }<br/>`;
+        }
+        stats_txt +=
           `<small>${i18n.t(
             "data_stats.displayed"
           )}</small>&nbsp;&ndash;&nbsp;` +
@@ -1195,11 +1199,9 @@ class IDE {
     this.codeEditor.setValue(query);
   }
   getQueryLang() {
-    const q = $.trim(this.getRawQuery().replace(/{{.*?}}/g, ""))
-    if (q.match(/^</))
-      return "xml";
-    else if (q.match(/^select/i))
-      return "SQL";
+    const q = $.trim(this.getRawQuery().replace(/{{.*?}}/g, ""));
+    if (q.match(/^</)) return "xml";
+    else if (q.match(/^select/i)) return "SQL";
     else return "OverpassQL";
   }
   /* this is for repairing obvious mistakes in the query, such as missing recurse statements */
@@ -1536,11 +1538,13 @@ class IDE {
       location.pathname.match(/.*\//)[0]
     }`;
     const query_lang = this.getQueryLang();
-    const server = (this.data_source &&
+    const server =
+      this.data_source &&
       this.data_source.options.server &&
       ((query_lang == "SQL" && this.data_source.mode == "sql") ||
-       this.data_source.mode == "overpass")) ? 
-          this.data_source.options.server : settings.server;
+        this.data_source.mode == "overpass")
+        ? this.data_source.options.server
+        : settings.server;
     let queryWithMapCSS = query;
     if (this.queryParser.hasStatement("style"))
       queryWithMapCSS += `{{style: ${this.queryParser.getStatement(
@@ -2722,11 +2726,13 @@ class IDE {
       }
     }
     const query_lang = this.getQueryLang();
-    const server = (this.data_source &&
+    const server =
+      this.data_source &&
       this.data_source.options.server &&
       ((query_lang == "SQL" && this.data_source.mode == "sql") ||
-       this.data_source.mode == "overpass")) ? 
-          this.data_source.options.server : settings.server;
+        this.data_source.mode == "overpass")
+        ? this.data_source.options.server
+        : settings.server;
 
     overpass.run_query(
       query,

--- a/js/ide.ts
+++ b/js/ide.ts
@@ -1224,9 +1224,9 @@ class IDE {
     this.codeEditor.setValue(query);
   }
   getQueryLang() {
+    if (this.data_source && this.data_source.mode == "sql") return "SQL";
     const q = $.trim(this.getRawQuery().replace(/{{.*?}}/g, ""));
     if (q.match(/^</)) return "xml";
-    else if (q.match(/^select/i)) return "SQL";
     else return "OverpassQL";
   }
   /* this is for repairing obvious mistakes in the query, such as missing recurse statements */
@@ -1562,12 +1562,10 @@ class IDE {
     const baseurl = `${location.protocol}//${location.host}${
       location.pathname.match(/.*\//)[0]
     }`;
-    const query_lang = this.getQueryLang();
     const server =
       this.data_source &&
       this.data_source.options.server &&
-      ((query_lang == "SQL" && this.data_source.mode == "sql") ||
-        this.data_source.mode == "overpass")
+      (this.data_source.mode == "sql" || this.data_source.mode == "overpass")
         ? this.data_source.options.server
         : settings.server;
     let queryWithMapCSS = query;
@@ -2754,8 +2752,7 @@ class IDE {
     const server =
       this.data_source &&
       this.data_source.options.server &&
-      ((query_lang == "SQL" && this.data_source.mode == "sql") ||
-        this.data_source.mode == "overpass")
+      (this.data_source.mode == "sql" || this.data_source.mode == "overpass")
         ? this.data_source.options.server
         : settings.server;
 

--- a/js/ide.ts
+++ b/js/ide.ts
@@ -383,6 +383,25 @@ class IDE {
           }
         )
       );
+      CodeMirror.defineMode("sql+mustache", (config) =>
+        CodeMirror.multiplexingMode(
+          CodeMirror.multiplexingMode(
+            CodeMirror.getMode(config, "text/x-sql"),
+            {
+              open: "{{",
+              close: "}}",
+              mode: CodeMirror.getMode(config, "text/plain"),
+              delimStyle: "mustache"
+            }
+          ),
+          {
+            open: "{{style:",
+            close: "}}",
+            mode: CodeMirror.getMode(config, "text/css"),
+            delimStyle: "mustache"
+          }
+        )
+      );
       ide.codeEditor = CodeMirror.fromTextArea($("#editor textarea")[0], {
         //value: settings.code["overpass"],
         lineNumbers: true,
@@ -397,6 +416,12 @@ class IDE {
                 e.closeTagEnabled = true;
                 e.setOption("matchBrackets", false);
                 e.setOption("mode", "xml+mustache");
+              }
+            } else if (ide.getQueryLang() == "SQL") {
+              if (e.getOption("mode") != "sql+mustache") {
+                e.closeTagEnabled = false;
+                e.setOption("matchBrackets", true);
+                e.setOption("mode", "sql+mustache");
               }
             } else {
               if (e.getOption("mode") != "ql+mustache") {

--- a/js/ide.ts
+++ b/js/ide.ts
@@ -25,7 +25,7 @@ import urlParameters from "./urlParameters";
 import Autorepair from "./autorepair";
 import {Base64, htmlentities, lzw_encode, lzw_decode} from "./misc";
 import sync from "./sync-with-osm";
-import shortcuts from "./shortcuts";
+import shortcuts, {Shortcut} from "./shortcuts";
 
 declare const CodeMirror;
 
@@ -329,7 +329,6 @@ class IDE {
     // init codemirror
     $("#editor textarea")[0].value = settings.code["overpass"];
     if (settings.use_rich_editor) {
-      let pending = 0;
       CodeMirror.defineMIME("text/x-overpassQL", {
         name: "clike",
         keywords: (function (str) {
@@ -407,51 +406,61 @@ class IDE {
         lineNumbers: true,
         lineWrapping: true,
         mode: "text/plain",
-        onChange(e) {
-          clearTimeout(pending);
-          pending = setTimeout(() => {
-            // update syntax highlighting mode
-            if (ide.getQueryLang() == "xml") {
-              if (e.getOption("mode") != "xml+mustache") {
-                e.closeTagEnabled = true;
-                e.setOption("matchBrackets", false);
-                e.setOption("mode", "xml+mustache");
+        onChange: _.debounce(
+          (e) => {
+            settings.code["overpass"] = e.getValue();
+            settings.save();
+            ide.getQuery({}).then(() => {
+              const query_lang = ide.getQueryLang();
+              // update syntax highlighting mode
+              switch (query_lang) {
+                case "xml":
+                  if (e.getOption("mode") != "xml+mustache") {
+                    e.closeTagEnabled = true;
+                    e.setOption("matchBrackets", false);
+                    e.setOption("mode", "xml+mustache");
+                  }
+                  break;
+                case "SQL":
+                  if (e.getOption("mode") != "sql+mustache") {
+                    e.closeTagEnabled = false;
+                    e.setOption("matchBrackets", true);
+                    e.setOption("mode", "sql+mustache");
+                  }
+                  break;
+                default:
+                  if (e.getOption("mode") != "ql+mustache") {
+                    e.closeTagEnabled = false;
+                    e.setOption("matchBrackets", true);
+                    e.setOption("mode", "ql+mustache");
+                  }
               }
-            } else if (ide.getQueryLang() == "SQL") {
-              if (e.getOption("mode") != "sql+mustache") {
-                e.closeTagEnabled = false;
-                e.setOption("matchBrackets", true);
-                e.setOption("mode", "sql+mustache");
+              // check for inactive ui elements
+              const bbox_filter = $(".leaflet-control-buttons-bboxfilter");
+              if (ide.getRawQuery().match(/\{\{bbox\}\}/)) {
+                if (bbox_filter.hasClass("disabled")) {
+                  bbox_filter.removeClass("disabled");
+                  bbox_filter.attr(
+                    "data-t",
+                    "[title]map_controlls.select_bbox"
+                  );
+                  i18n.translate_ui(bbox_filter[0]);
+                }
+              } else {
+                if (!bbox_filter.hasClass("disabled")) {
+                  bbox_filter.addClass("disabled");
+                  bbox_filter.attr(
+                    "data-t",
+                    "[title]map_controlls.select_bbox_disabled"
+                  );
+                  i18n.translate_ui(bbox_filter[0]);
+                }
               }
-            } else {
-              if (e.getOption("mode") != "ql+mustache") {
-                e.closeTagEnabled = false;
-                e.setOption("matchBrackets", true);
-                e.setOption("mode", "ql+mustache");
-              }
-            }
-            // check for inactive ui elements
-            const bbox_filter = $(".leaflet-control-buttons-bboxfilter");
-            if (ide.getRawQuery().match(/\{\{bbox\}\}/)) {
-              if (bbox_filter.hasClass("disabled")) {
-                bbox_filter.removeClass("disabled");
-                bbox_filter.attr("data-t", "[title]map_controlls.select_bbox");
-                i18n.translate_ui(bbox_filter[0]);
-              }
-            } else {
-              if (!bbox_filter.hasClass("disabled")) {
-                bbox_filter.addClass("disabled");
-                bbox_filter.attr(
-                  "data-t",
-                  "[title]map_controlls.select_bbox_disabled"
-                );
-                i18n.translate_ui(bbox_filter[0]);
-              }
-            }
-          }, 500);
-          settings.code["overpass"] = e.getValue();
-          settings.save();
-        },
+            });
+          },
+          100,
+          {leading: true, trailing: true}
+        ),
         closeTagEnabled: true,
         closeTagIndent: [
           "osm-script",
@@ -1185,7 +1194,9 @@ class IDE {
 
   /* this returns the current query in the editor.
    * shortcuts are expanded. */
-  async getQuery(): Promise<string> {
+  async getQuery(
+    _shortcuts: Record<string, Shortcut> = undefined
+  ): Promise<string> {
     let query = this.getRawQuery();
     // parse query and process shortcuts
     // special handling for global bbox in xml queries (which uses an OverpassQL-like notation instead of n/s/e/w parameters):
@@ -1193,7 +1204,10 @@ class IDE {
       /(<osm-script[^>]+bbox[^=]*=[^"'']*["'])({{bbox}})(["'])/,
       "$1{{__bbox__global_bbox_xml__ezs4K8__}}$3"
     );
-    query = await this.queryParser.parse(query, shortcuts());
+    query = await this.queryParser.parse(
+      query,
+      _shortcuts ? _shortcuts : shortcuts()
+    );
     // parse mapcss declarations
     let mapcss = "";
     if (this.queryParser.hasStatement("style"))

--- a/js/index.ts
+++ b/js/index.ts
@@ -10,6 +10,7 @@ import "codemirror/mode/javascript/javascript";
 import "codemirror/mode/xml/xml";
 import "codemirror/mode/clike/clike";
 import "codemirror/mode/css/css";
+import "codemirror/mode/sql/sql";
 import "codemirror/lib/util/multiplex";
 import "codemirror/lib/util/closetag";
 

--- a/js/map.ts
+++ b/js/map.ts
@@ -32,6 +32,7 @@ $(document).ready(() => {
           cache,
           true,
           undefined,
+          undefined,
           ide.mapcss
         );
       }
@@ -103,6 +104,7 @@ $(document).ready(() => {
         query_lang,
         cache,
         false,
+        undefined,
         undefined,
         ide.mapcss
       );

--- a/js/overpass.ts
+++ b/js/overpass.ts
@@ -296,7 +296,7 @@ class Overpass {
                 }
               });
             } else if (data.osm3s) {
-              // maybe json data
+              // json data from Overpass
               overpass.resultType = "javascript";
               data_mode = "json";
               overpass.timestamp = data.osm3s.timestamp_osm_base;
@@ -311,9 +311,16 @@ class Overpass {
               };
               //// convert to geoJSON
               //geojson = overpass.overpassJSON2geoJSON(data);
+            } else if (
+              typeof data === "object" &&
+              data?.type === "FeatureCollection"
+            ) {
+              // geojson directly from a source like Postpass
+              data_mode = "geojson";
             } else {
-              // fixme how to show text in data view but not try to render map?
-              data_mode = "text";
+              // other json / unknown
+              data_mode = "unknown";
+              data = {elements: []};
             }
 
             //overpass.fire("onProgress", "applying styles"); // doesn't correspond to what's really going on. (the whole code could in principle be put further up and called "preparing mapcss styles" or something, but it's probably not worth the effort)

--- a/js/overpass.ts
+++ b/js/overpass.ts
@@ -194,8 +194,7 @@ class Overpass {
                   data.remark &&
                   data.remark.length > 0);
               is_error ||=
-                typeof data == "string" &&
-                data.indexOf("pq: syntax error") != -1;
+                typeof data == "string" && data.match(/^(pq|sql): /) !== null;
               if (is_error) {
                 // this really looks like an error message, so lets open an additional modal error message
                 let errmsg = "?";
@@ -797,7 +796,9 @@ class Overpass {
           if (
             jqXHR.status == 400 ||
             jqXHR.status == 504 ||
-            jqXHR.status == 429
+            jqXHR.status == 429 ||
+            (jqXHR.status == 500 &&
+              jqXHR.responseText.match(/^(pq|sql): /) !== null) // postgresql error messages
           ) {
             // todo: handle those in a separate routine
             // pass 400 Bad Request errors to the standard result parser, as this is most likely going to be a syntax error in the query.

--- a/js/overpass.ts
+++ b/js/overpass.ts
@@ -280,13 +280,15 @@ class Overpass {
                     continue;
                   feature.properties.tags[key] = feature.properties[key];
                 }
-                if (feature.properties.osm_id < 0) {
-                  feature.properties.type = "relation";
-                  feature.properties.id = -feature.properties.osm_id;
-                } else {
-                  feature.properties.type =
-                    feature.geometry.type === "Point" ? "node" : "way";
-                  feature.properties.id = feature.properties.osm_id;
+                if (feature.properties.osm_id) {
+                  if (feature.properties.osm_id < 0) {
+                    feature.properties.type = "relation";
+                    feature.properties.id = -feature.properties.osm_id;
+                  } else {
+                    feature.properties.type =
+                      feature.geometry.type === "Point" ? "node" : "way";
+                    feature.properties.id = feature.properties.osm_id;
+                  }
                 }
               });
             } else {

--- a/js/overpass.ts
+++ b/js/overpass.ts
@@ -192,6 +192,9 @@ class Overpass {
                 (typeof data == "object" &&
                   data.remark &&
                   data.remark.length > 0);
+              is_error ||=
+                typeof data == "string" &&
+                data.indexOf("pq: syntax error") != -1;
               if (is_error) {
                 // this really looks like an error message, so lets open an additional modal error message
                 let errmsg = "?";

--- a/js/overpass.ts
+++ b/js/overpass.ts
@@ -6,6 +6,7 @@ import L_PopupIcon from "./PopupIcon"; // eslint-disable-line @typescript-eslint
 import L_OSM4Leaflet from "./OSM4Leaflet";
 import L_GeoJsonNoVanish from "./GeoJsonNoVanish";
 
+import ide from "./ide";
 import configs from "./configs";
 import settings from "./settings";
 import {htmlentities} from "./misc";
@@ -82,11 +83,12 @@ class Overpass {
     }
     overpass.fire(
       "onProgress",
-      "calling Overpass API interpreter",
+      `calling ${ide.getQueryLang() === "SQL" ? "SQL Server" : "Overpass API interpreter"}`,
       (callback) => {
         // kill the query on abort
         overpass.ajax_request.abort();
-        // try to abort queries via kill_my_queries
+        if (ide.getQueryLang() === "SQL") return callback();
+        // try to abort Overpass API queries via kill_my_queries
         $.get(`${server}kill_my_queries`)
           .done(callback)
           .fail(() => {

--- a/js/overpass.ts
+++ b/js/overpass.ts
@@ -295,7 +295,7 @@ class Overpass {
                   }
                 }
               });
-            } else {
+            } else if (data.osm3s) {
               // maybe json data
               overpass.resultType = "javascript";
               data_mode = "json";
@@ -312,6 +312,12 @@ class Overpass {
               //// convert to geoJSON
               //geojson = overpass.overpassJSON2geoJSON(data);
             }
+            else
+            {
+              // fixme how to show text in data view but not try to render map?
+              data_mode = "text";
+            }
+
 
             //overpass.fire("onProgress", "applying styles"); // doesn't correspond to what's really going on. (the whole code could in principle be put further up and called "preparing mapcss styles" or something, but it's probably not worth the effort)
 

--- a/js/overpass.ts
+++ b/js/overpass.ts
@@ -67,6 +67,7 @@ class Overpass {
     cache,
     shouldCacheOnly = false,
     server: string,
+    options,
     user_mapcss: string
   ) {
     // eslint-disable-next-line @typescript-eslint/no-this-alias
@@ -778,7 +779,7 @@ class Overpass {
       overpass.ajax_request_start = Date.now();
       overpass.ajax_request = $.ajax(`${server}interpreter`, {
         type: "POST",
-        data: {data: query},
+        data: {data: query, options: options },
         success: onSuccessCb,
         error(jqXHR, textStatus) {
           if (textStatus == "abort") return; // ignore aborted queries.

--- a/js/overpass.ts
+++ b/js/overpass.ts
@@ -311,13 +311,10 @@ class Overpass {
               };
               //// convert to geoJSON
               //geojson = overpass.overpassJSON2geoJSON(data);
-            }
-            else
-            {
+            } else {
               // fixme how to show text in data view but not try to render map?
               data_mode = "text";
             }
-
 
             //overpass.fire("onProgress", "applying styles"); // doesn't correspond to what's really going on. (the whole code could in principle be put further up and called "preparing mapcss styles" or something, but it's probably not worth the effort)
 
@@ -785,7 +782,7 @@ class Overpass {
       overpass.ajax_request_start = Date.now();
       overpass.ajax_request = $.ajax(`${server}interpreter`, {
         type: "POST",
-        data: {data: query, options: options },
+        data: {data: query, options: options},
         success: onSuccessCb,
         error(jqXHR, textStatus) {
           if (textStatus == "abort") return; // ignore aborted queries.

--- a/js/popup.ts
+++ b/js/popup.ts
@@ -26,8 +26,8 @@ export function featurePopupContent(feature: GeoJSON.Feature) {
       ` <a href="//www.openstreetmap.org/relation/${feature.properties.id}" target="_blank">${feature.properties.id}</a>` +
       ` <a href="//www.openstreetmap.org/edit?relation=${feature.properties.id}" target="_blank">✏</a>` +
       `</h4>`;
-  else
-    popup += `<h5 class="subtitle is-5">${feature.properties.type} #${feature.properties.id}</h5>`;
+  else if (feature.properties.id)
+    popup += `<h5 class="subtitle is-5">${feature.properties.type || ""} #${feature.properties.id}</h5>`;
   if (
     feature.properties &&
     feature.properties.tags &&

--- a/js/shortcuts.ts
+++ b/js/shortcuts.ts
@@ -16,7 +16,7 @@ function map2bbox(lang) {
   if (lang == "OverpassQL") return `${lat1},${lng1},${lat2},${lng2}`;
   else if (lang == "xml")
     return `s="${lat1}" w="${lng1}" n="${lat2}" e="${lng2}"`;
-  else if (lang == "SQL" )
+  else if (lang == "SQL")
     return `st_setsrid(st_makebox2d(st_makepoint(${lng1},${lat1}), st_makepoint(${lng2},${lat2})), 4326)`;
 }
 

--- a/js/shortcuts.ts
+++ b/js/shortcuts.ts
@@ -16,6 +16,8 @@ function map2bbox(lang) {
   if (lang == "OverpassQL") return `${lat1},${lng1},${lat2},${lng2}`;
   else if (lang == "xml")
     return `s="${lat1}" w="${lng1}" n="${lat2}" e="${lng2}"`;
+  else if (lang == "SQL" )
+    return `st_setsrid(st_makebox2d(st_makepoint(${lng1},${lat1}), st_makepoint(${lng2},${lat2})), 4326)`;
 }
 
 // returns the current visible map center as a coord-query


### PR DESCRIPTION
Now you can use `{{data:sql,server=…}}` to send queries to a [`postpass`](https://github.com/woodpeck/postpass) backend, which returns results in GeoJSON (or text for non-geo answers).

Kudos to @woodpeck for the server side implementation and help with the implementation in overpass turbo. See also https://media.ccc.de/v/fossgis2025-58235-overpass-turbo-goes-postgis (conference talk in German).

todo:

* [x] better handle http 500 error codes from backend, see https://github.com/woodpeck/postpass/issues/9