### PR TITLE
Fix request dialogue never closing when receiving empty result set from Postpass query

### DIFF
--- a/js/overpass.ts
+++ b/js/overpass.ts
@@ -718,7 +718,7 @@ class Overpass {
                       // switch only if there is some unplottable data in the returned json/xml.
                       let empty_msg;
                       if (
-                        (data_mode == "json" && data.elements.length > 0) ||
+                        (data_mode == "json" && data.elements?.length > 0) ||
                         (data_mode == "xml" &&
                           $("osm", data).children().not("note,meta,bounds")
                             .length > 0)


### PR DESCRIPTION
Postpass queries are data_mode "json" too, but data.elements only exists
in overpass JSON responses.  This resulted in “TypeError: data.elements
is undefined” which prevented the request dialogue from properly
closing.

Fixes #772
