### PR TITLE
Make favicon adaptive to light/dark color-scheme

### DIFF
--- a/css/default.css
+++ b/css/default.css
@@ -3,6 +3,7 @@ html {
   overflow-y: auto;
 }
 body {
+  color-scheme: light;
   background-color: white;
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 }

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
     />
     <meta name="viewport" content="width=device-width" />
     <title>overpass turbo</title>
+    <link rel="icon" href="turbo.svg" sizes="any" type="image/svg+xml" />
     <!-- https://developers.facebook.com/docs/sharing/webmasters -->
     <meta property="og:title" content="overpass turbo" />
     <meta

--- a/turbo.svg
+++ b/turbo.svg
@@ -4,18 +4,27 @@
     <path
        d="M 15,8 A 7,7 0 1 1 1,8 7,7 0 1 1 15,8 z"
        id="circle"
-       style="fill:none;stroke:#000000;stroke-width:1.5" />
+       style="fill:none;stroke-width:1.5" />
     <path
        d="m 1,6 c 0,0 4.5,3 7,3 2.5,0 7,-3 7,-3"
        id="roundshape"
-       style="fill:none;stroke:#000000;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+       style="fill:none;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     <path
        d="M 8,15 8,9"
        id="verticalbar"
-       style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+       style="fill:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     <path
        d="M 13,7.5 3,7.5"
        id="horizbar"
-       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+       style="fill:none;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   </g>
+  <style>
+    path {
+      stroke: #000000;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      path { stroke: #ffffff; }
+    }
+  </style>
 </svg>


### PR DESCRIPTION
Fixes #744 

Light color-scheme:
<img width="306" height="132" alt="Screenshot 2025-08-10 at 07 13 55" src="https://github.com/user-attachments/assets/fa8f51d0-cfb2-4750-8951-522d1a8985ba" />

Dark color-scheme:
<img width="292" height="100" alt="Screenshot 2025-08-10 at 07 14 03" src="https://github.com/user-attachments/assets/52d4088b-13a7-4c45-8244-d50dab9f6d34" />
