### PR TITLE
Fixup: store constructed 'Attribution' control on IDE instance

### DIFF
--- a/js/ide.ts
+++ b/js/ide.ts
@@ -526,7 +526,7 @@ class IDE {
       maxNativeZoom: 19,
       maxZoom: ide.map.options.maxZoom
     });
-    const attribControl = new L.Control.Attribution({position: "bottomright"});
+    const attribControl = ide.attribControl = new L.Control.Attribution({position: "bottomright"});
     attribControl.addAttribution(tilesAttrib);
     attribControl.addTo(ide.map);
     const pos = new L.LatLng(settings.coords_lat, settings.coords_lon);


### PR DESCRIPTION
...so that it can later be accessed during image export: https://github.com/tyrasd/overpass-turbo/blob/eb5d0f57d82d1a469d14dd4351aead200615a3f3/js/ide.ts#L2275

May resolve #791.