### PR TITLE
Remove overpass.openstreetmap.ru instance

### DIFF
--- a/js/configs.ts
+++ b/js/configs.ts
@@ -8,7 +8,6 @@ export default {
     "https://overpass-api.de/api/",
     "https://overpass-api.de/api/",
     "https://maps.mail.ru/osm/tools/overpass/api/",
-    "https://overpass.openstreetmap.ru/api/",
     "https://overpass.kumi.systems/api/"
   ],
   defaultTiles: "https://tile.openstreetmap.org/{z}/{x}/{y}.png",


### PR DESCRIPTION
This server is no longer supported, and the domain was recently disabled.

I see browser storage migrations in the code, but I'm a little scared to do any deletions to the storage without proper testing.