### PR TITLE
bug: fix ReferenceError

### DIFF
--- a/js/GeoJsonNoVanish.ts
+++ b/js/GeoJsonNoVanish.ts
@@ -1,3 +1,5 @@
+import * as L from 'leaflet';
+
 class GeoJsonNoVanish extends L.GeoJSON {
   threshold = 10;
   constructor(geojson, options) {


### PR DESCRIPTION
As described in issue https://github.com/tyrasd/overpass-turbo/issues/827 running 

```
npm install
npm run build
```

And then serving the resulting dist folder, results in a page that displays a never ending loading spinner and the console displays:

```
  Uncaught ReferenceError: L is not defined                                                                                                                                                                                                                                                                       
      <anonymous> GeoJsonNoVanish.ts:1                                                                                                                                                                                                                                                                            
  GeoJsonNoVanish.ts:1:1   
```

I believe the fix is likely something along the lines of this PR. I have tested this change locally.

Oddly it all seems to work fine with `npm run dev`, it's on the built dist which is shows the problem.