### PR TITLE
Add {{wsen}} shortcut, like {{bbox}}, for overpass ultra compatibility with postpass

### DIFF
--- a/index.html
+++ b/index.html
@@ -284,6 +284,10 @@
                   <span class="t" data-t="help.intro.shortcuts.bbox"></span>
                 </li>
                 <li>
+                  <code>{{wsen}}</code> &mdash;
+                  <span class="t" data-t="help.intro.shortcuts.wsen"></span>
+                </li>
+                <li>
                   <code>{{center}}</code> &mdash;
                   <span class="t" data-t="help.intro.shortcuts.center"></span>
                 </li>

--- a/js/shortcuts.ts
+++ b/js/shortcuts.ts
@@ -27,6 +27,20 @@ function map2bbox(lang) {
     return `st_setsrid(st_makebox2d(st_makepoint(${lng1},${lat1}), st_makepoint(${lng2},${lat2})), 4326)`;
 }
 
+
+function map2wsen() {
+  let bbox;
+  if (!(ide.map.bboxfilter && ide.map.bboxfilter.isEnabled()))
+    bbox = ide.map.getBounds();
+  else bbox = ide.map.bboxfilter.getBounds();
+  const south = Math.min(Math.max(bbox.getSouthWest().lat, -90), 90);
+  const north = Math.min(Math.max(bbox.getNorthEast().lat, -90), 90);
+  const west = Math.min(Math.max(bbox.getSouthWest().lng, -180), 180);
+  const east = Math.min(Math.max(bbox.getNorthEast().lng, -180), 180);
+
+  return `${west},${south},${east},${north}`;
+}
+
 // returns the current visible map center as a coord-query
 function map2coord(lang) {
   const center = ide.map.getCenter();
@@ -155,6 +169,7 @@ export default function shortcuts(): Record<string, Shortcut> {
   const queryLang = ide.getQueryLang();
   return {
     bbox: map2bbox(queryLang),
+    wsen: map2wsen(),
     center: map2coord(queryLang),
     // special handling for global bbox in xml queries (which uses an OverpassQL-like notation instead of n/s/e/w parameters):
     __bbox__global_bbox_xml__ezs4K8__: map2bbox("OverpassQL"),

--- a/js/shortcuts.ts
+++ b/js/shortcuts.ts
@@ -27,17 +27,16 @@ function map2bbox(lang) {
     return `st_setsrid(st_makebox2d(st_makepoint(${lng1},${lat1}), st_makepoint(${lng2},${lat2})), 4326)`;
 }
 
-
+// returns the current visible bbox in west,south,east,north order
 function map2wsen() {
   let bbox;
   if (!(ide.map.bboxfilter && ide.map.bboxfilter.isEnabled()))
     bbox = ide.map.getBounds();
   else bbox = ide.map.bboxfilter.getBounds();
-  const south = Math.min(Math.max(bbox.getSouthWest().lat, -90), 90);
-  const north = Math.min(Math.max(bbox.getNorthEast().lat, -90), 90);
-  const west = Math.min(Math.max(bbox.getSouthWest().lng, -180), 180);
-  const east = Math.min(Math.max(bbox.getNorthEast().lng, -180), 180);
-
+  const south = coord(bbox.getSouthWest().lat, 90);
+  const north = coord(bbox.getNorthEast().lat, 90);
+  const west = coord(bbox.getSouthWest().lng, 180);
+  const east = coord(bbox.getNorthEast().lng, 180);
   return `${west},${south},${east},${north}`;
 }
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -137,6 +137,7 @@
   "help.queries.expl": "Overpass API allows to query for OSM data by your own search criteria. For this purpose, it has a specifically crafted <a href=\"https://wiki.openstreetmap.org/wiki/Overpass_API/Overpass_QL\">query language</a>.",
   "help.intro.shortcuts": "In addition to regular Overpass API queries one can use the following handy shortcuts in overpass turbo:",
   "help.intro.shortcuts.bbox": "bounding box coordinates of the current map view",
+  "help.intro.shortcuts.wsen": "bounding box coordinates of the current map view in west,south,east,north order",
   "help.intro.shortcuts.center": "map center coordinates",
   "help.intro.shortcuts.date": "ISO 8601 date-time-string a certain time interval ago (e.g. “24 hours”)",
   "help.intro.shortcuts.style": "defines a <a href=\"https://wiki.openstreetmap.org/wiki/Overpass_turbo/MapCSS\">MapCSS stylesheet</a>",

--- a/tests/test.query.ts
+++ b/tests/test.query.ts
@@ -104,6 +104,15 @@ describe("ide.query", () => {
       await expect(ide.getQuery()).resolves.toBe(example.outp);
     }
   });
+  // expand {{wsen}}
+  it("expand {{wsen}}", async () => {
+    vi.spyOn(ide, "setQuery").mockImplementation(() => {});
+    // same bbox as {{bbox}}, but in west,south,east,north order
+    ide.codeEditor.getValue = () => "({{wsen}})";
+    await expect(ide.getQuery()).resolves.toBe(
+      "(2.0000000,1.0000000,4.0000000,3.0000000)"
+    );
+  });
   // expand {{center}}
   it("expand {{center}}", async () => {
     vi.spyOn(ide, "setQuery").mockImplementation(() => {});

--- a/tests/test.query.ts
+++ b/tests/test.query.ts
@@ -86,17 +86,19 @@ describe("ide.query", () => {
       {
         // ql query
         inp: "({{bbox}})",
-        outp: "(1,2,3,4)"
+        outp: "(1.0000000,2.0000000,3.0000000,4.0000000)"
       },
       {
         // xml query
         inp: "<bbox-query {{bbox}}/>",
-        outp: '<bbox-query s="1" w="2" n="3" e="4"/>'
+        outp:
+          '<bbox-query s="1.0000000" w="2.0000000" ' +
+          'n="3.0000000" e="4.0000000"/>'
       },
       {
         // xml query global bbox
         inp: '<osm-script bbox="{{bbox}}"/>',
-        outp: '<osm-script bbox="1,2,3,4"/>'
+        outp: '<osm-script bbox="1.0000000,2.0000000,3.0000000,4.0000000"/>'
       }
     ];
     for (const example of examples) {
@@ -120,12 +122,12 @@ describe("ide.query", () => {
       {
         // ql query
         inp: "({{center}})",
-        outp: "(5,6)"
+        outp: "(5.0000000,6.0000000)"
       },
       {
         // xml query
         inp: "<around {{center}}/>",
-        outp: '<around lat="5" lon="6"/>'
+        outp: '<around lat="5.0000000" lon="6.0000000"/>'
       }
     ];
     for (const example of examples) {


### PR DESCRIPTION
{{wsen}} = west, south, east, north, e.g.
`-0.14965011221224245,51.4291792503295,0.15609219001041197,51.57889517408489`. This can be used for PostPass/PostGIS with `ST_MakeEnvelope({{wsen}}, 4326)`. Overpass Turbo & Ultra (née Overpass Ultra) both have a `{{bbox}}` shortcut, but each give different results. A postpass/postgis query which uses this has be rewritten to work on the other.

With this patch, a PostGIS/Postpass query can be written that works the same in Overpass Turbo & Ultra (by using `{{wsen}}` instead of `{{bbox}}`).

--- 

You can see many uses of the `{{wsen}}` on the [Postpass examples](https://wiki.openstreetmap.org/wiki/Postpass/Examples) page. I opened [an issue](https://gitlab.com/trailstash/ultra/-/work_items/55) for Ultra asking for language dependent `{{bbox}}` handling, like how Overpass Turbo does it.

Ultra's handling of shortcuts ([`bounds.js`](https://gitlab.com/trailstash/ultra/-/blob/main/lib/bounds.js)], shows how it supports other shortcuts; like `{{wens}}`, `{{west}}`; but this patch _only_ adds `{{wsen}}`. I think it would be nice to have full coverage of the others.

--- 

I was unable to test this patch because the install instructions didn't work on my debian linux desktop. I tried to manually install `pnpm` which worked by couldn't install overpass turbo because of differnet node versions.

Hence this PR is in draft mode, Please feel free to test it and correct any glaring mistakes.