### PR TITLE
Add a parser for the public Overpass instances listed on the OSM wiki

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ These changes are live on the development instance at <https://tyrasd.github.io/
 - Round `{{bbox}}`/`{{center}}` coordinates to 7 decimal places ([#832](https://github.com/tyrasd/overpass-turbo/issues/832))
 - Fall back to the English string for untranslated keys
 - Restore login to osm.org via popup
+- Suggest the servers listed on the [Overpass API wiki page](https://wiki.openstreetmap.org/wiki/Overpass_API#Public_Overpass_API_instances) in the settings dialog, and show the data coverage and usage policy of the selected server ([#854](https://github.com/tyrasd/overpass-turbo/pull/854))
+- Remove duplicate overpass-api.de entry from the suggested servers
 - Remove overpass.openstreetmap.ru instance ([#816](https://github.com/tyrasd/overpass-turbo/issues/816))
 - Update link for overpass.private.coffee instance
 - Try to render results even if parsing fails for some reason

--- a/index.html
+++ b/index.html
@@ -609,6 +609,7 @@
                   value=""
                   id="server"
                 />
+                <p class="help" id="server-info"></p>
               </div>
             </div>
             <div class="field">

--- a/js/configs.ts
+++ b/js/configs.ts
@@ -3,6 +3,8 @@ export default {
   // used for localStorage and openstreetmap.org/api/0.6/user/preferences
   settingNamespace: "overpass-ide",
   defaultServer: "https://overpass-api.de/api/",
+  // the remaining suggestions are read from the wiki at runtime, see
+  // js/overpass-servers.ts — these two are the fallback when it is unreachable
   // https://wiki.openstreetmap.org/wiki/Overpass_API#Public_Overpass_API_instances
   suggestedServers: [
     "https://overpass-api.de/api/",

--- a/js/configs.ts
+++ b/js/configs.ts
@@ -6,7 +6,6 @@ export default {
   // https://wiki.openstreetmap.org/wiki/Overpass_API#Public_Overpass_API_instances
   suggestedServers: [
     "https://overpass-api.de/api/",
-    "https://overpass-api.de/api/",
     "https://maps.mail.ru/osm/tools/overpass/api/",
     "https://overpass.private.coffee/api/"
   ],

--- a/js/ide.ts
+++ b/js/ide.ts
@@ -24,7 +24,7 @@ import i18n from "./i18n";
 import * as josm from "./josmRemoteControl";
 import {Base64, htmlentities, lzw_encode, lzw_decode} from "./misc";
 import overpass, {type QueryLang} from "./overpass";
-import {fetchInstances} from "./overpass-servers";
+import {fetchInstances, type OverpassInstance} from "./overpass-servers";
 import Query from "./query";
 import settings from "./settings";
 import shortcuts, {Shortcut} from "./shortcuts";
@@ -123,6 +123,8 @@ $(document).on("copy", (e) => {
 // the hardcoded servers, extended with the instances listed on the OSM wiki
 // once the settings dialog has been opened
 let suggestedServers = configs.suggestedServers;
+// what the wiki says about those instances, to describe the selected one
+let wikiInstances: OverpassInstance[] = [];
 
 function make_combobox(
   input: JQuery<HTMLElement>,
@@ -2653,11 +2655,32 @@ class IDE {
         }
       );
     make_server_combobox(suggestedServers);
+    // describes the server currently in the input, as far as the wiki knows it
+    const show_server_info = () => {
+      const server = $<HTMLInputElement>(
+        "#settings-dialog input[name=server]"
+      )[0].value;
+      const instance = wikiInstances.find(({url}) => url === server);
+      const coverage =
+        instance?.coverage &&
+        `${i18n.t("settings.server_coverage")}: ${instance.coverage}`;
+      // .text(), never .html(): this comes from a world-writable wiki
+      $("#settings-dialog #server-info").text(
+        [coverage, instance?.usagePolicy].filter(Boolean).join(" — ")
+      );
+    };
+    $("#settings-dialog input[name=server]").on(
+      "input autocompleteselect autocompletechange",
+      // the combobox fills the input after the event, hence the deferral
+      () => setTimeout(show_server_info)
+    );
+    show_server_info();
     // the instances listed on the OSM wiki trickle in afterwards, the combobox
     // is rebuilt once they do. if the wiki cannot be reached, the hardcoded
     // servers are kept
     void fetchInstances()
       .then((instances) => {
+        wikiInstances = instances;
         suggestedServers = [
           ...new Set([
             ...configs.suggestedServers,
@@ -2665,6 +2688,7 @@ class IDE {
           ])
         ];
         make_server_combobox(suggestedServers);
+        show_server_info();
       })
       .catch(() => {});
     $<HTMLInputElement>(

--- a/js/ide.ts
+++ b/js/ide.ts
@@ -125,6 +125,9 @@ $(document).on("copy", (e) => {
 let suggestedServers = configs.suggestedServers;
 // what the wiki says about those instances, to describe the selected one
 let wikiInstances: OverpassInstance[] = [];
+// the wiki is queried once per session, on the first open of the settings
+// dialog; every later open reuses the result
+let instancesPromise: Promise<OverpassInstance[]> | undefined;
 
 function make_combobox(
   input: JQuery<HTMLElement>,
@@ -2669,16 +2672,20 @@ class IDE {
         [coverage, instance?.usagePolicy].filter(Boolean).join(" — ")
       );
     };
-    $("#settings-dialog input[name=server]").on(
-      "input autocompleteselect autocompletechange",
-      // the combobox fills the input after the event, hence the deferral
-      () => setTimeout(show_server_info)
-    );
+    $("#settings-dialog input[name=server]")
+      // `show_server_info` is recreated on every open, so drop the previous
+      // handler first — namespaced, as the combobox listens on `input` too
+      .off(".server-info")
+      .on(
+        "input.server-info autocompleteselect.server-info autocompletechange.server-info",
+        // the combobox fills the input after the event, hence the deferral
+        () => setTimeout(show_server_info)
+      );
     show_server_info();
     // the instances listed on the OSM wiki trickle in afterwards, the combobox
     // is rebuilt once they do. if the wiki cannot be reached, the hardcoded
     // servers are kept
-    void fetchInstances()
+    void (instancesPromise ??= fetchInstances())
       .then((instances) => {
         wikiInstances = instances;
         suggestedServers = [

--- a/js/ide.ts
+++ b/js/ide.ts
@@ -24,6 +24,7 @@ import i18n from "./i18n";
 import * as josm from "./josmRemoteControl";
 import {Base64, htmlentities, lzw_encode, lzw_decode} from "./misc";
 import overpass, {type QueryLang} from "./overpass";
+import {fetchInstances} from "./overpass-servers";
 import Query from "./query";
 import settings from "./settings";
 import shortcuts, {Shortcut} from "./shortcuts";
@@ -118,6 +119,10 @@ $(document).on("copy", (e) => {
     copyData = null;
   }
 });
+
+// the hardcoded servers, extended with the instances listed on the OSM wiki
+// once the settings dialog has been opened
+let suggestedServers = configs.suggestedServers;
 
 function make_combobox(
   input: JQuery<HTMLElement>,
@@ -2634,18 +2639,34 @@ class IDE {
       settings.theme;
     $<HTMLInputElement>("#settings-dialog input[name=server]")[0].value =
       settings.server;
-    make_combobox(
-      $("#settings-dialog input[name=server]"),
-      configs.suggestedServers.concat(settings.customServers),
-      settings.customServers,
-      (server) => {
-        settings.customServers.splice(
-          settings.customServers.indexOf(server),
-          1
-        );
-        settings.save();
-      }
-    );
+    const make_server_combobox = (servers: string[]) =>
+      make_combobox(
+        $("#settings-dialog input[name=server]"),
+        servers.concat(settings.customServers),
+        settings.customServers,
+        (server) => {
+          settings.customServers.splice(
+            settings.customServers.indexOf(server),
+            1
+          );
+          settings.save();
+        }
+      );
+    make_server_combobox(suggestedServers);
+    // the instances listed on the OSM wiki trickle in afterwards, the combobox
+    // is rebuilt once they do. if the wiki cannot be reached, the hardcoded
+    // servers are kept
+    void fetchInstances()
+      .then((instances) => {
+        suggestedServers = [
+          ...new Set([
+            ...configs.suggestedServers,
+            ...instances.map((instance) => instance.url)
+          ])
+        ];
+        make_server_combobox(suggestedServers);
+      })
+      .catch(() => {});
     $<HTMLInputElement>(
       "#settings-dialog input[name=no_autorepair]"
     )[0].checked = settings.no_autorepair;
@@ -2729,7 +2750,7 @@ class IDE {
       "#settings-dialog input[name=server]"
     )[0].value;
     if (
-      configs.suggestedServers.indexOf(settings.server) === -1 &&
+      suggestedServers.indexOf(settings.server) === -1 &&
       settings.customServers.indexOf(settings.server) === -1
     ) {
       settings.customServers.push(settings.server);

--- a/js/overpass-servers.ts
+++ b/js/overpass-servers.ts
@@ -33,6 +33,10 @@ export interface OverpassInstance {
   url: string;
   /** whether the instance serves the whole planet or only a single region */
   scope: "global" | "regional";
+  /** the region the data is limited to, for regional instances */
+  coverage?: string;
+  /** what the operator asks of its users, as plain text */
+  usagePolicy?: string;
 }
 
 /** splits a wikitable row into its cells, dropping any `scope="col"` markup */
@@ -56,6 +60,29 @@ function normalize(url: string): string {
   return url.replace(/interpreter\/?$/, "").replace(/\/?$/, "/");
 }
 
+/**
+ * Reduces the wikitext of a table cell to plain text: links keep their label
+ * (external ones also their target), footnotes and templates are dropped.
+ *
+ * The result is deliberately text and not HTML — the wiki is world-writable,
+ * so its markup must never end up in the DOM as markup.
+ */
+function plainText(wikitext: string): string {
+  return wikitext
+    .replace(/<ref[^>]*\/>|<ref[^>]*>[\s\S]*?<\/ref>/g, "") // footnotes
+    .replace(/\[\[[^\]|]*\|([^\]]*)\]\]/g, "$1") // [[Page|label]]
+    .replace(/\[\[([^\]]*)\]\]/g, "$1") // [[Page]]
+    .replace(/\[(https?:\/\/\S+)\s+([^\]]*)\]/g, "$2 ($1)") // [url label]
+    .replace(/\[(https?:\/\/[^\]\s]+)\]/g, "$1") // [url]
+    .replace(/\{\{[Uu]ser\|([^|}]*)[^}]*\}\}/g, "$1") // {{User|name|…}}
+    .replace(/\{\{[^{}]*\}\}/g, "") // any other template
+    .replace(/<br\s*\/?>/gi, " ")
+    .replace(/<[^>]+>/g, "") // syntaxhighlight and friends
+    .replace(/'''?/g, "") // bold/italic
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
 /** parses the instance tables out of the raw wikitext of the Overpass API page */
 export function parseInstances(wikitext: string): OverpassInstance[] {
   const instances = new Map<string, OverpassInstance>();
@@ -70,17 +97,25 @@ export function parseInstances(wikitext: string): OverpassInstance[] {
     const headers = cells(rows[0]);
     const endpointColumn = headers.findIndex((h) => /API Endpoint/i.test(h));
     if (endpointColumn === -1) continue; // not an instance table
-    const scope = headers.some((h) => /Data coverage/i.test(h))
-      ? "regional"
-      : "global";
+    const coverageColumn = headers.findIndex((h) => /Data coverage/i.test(h));
+    const usagePolicyColumn = headers.findIndex((h) => /Usage policy/i.test(h));
+    const scope = coverageColumn === -1 ? "global" : "regional";
 
     for (const row of rows.slice(1)) {
-      const cell = cells(row)[endpointColumn];
-      const url = cell?.replace(/<[^>]+>/g, "").match(/https?:\/\/\S+/)?.[0];
+      const rowCells = cells(row);
+      const url = rowCells[endpointColumn]
+        ?.replace(/<[^>]+>/g, "")
+        .match(/https?:\/\/\S+/)?.[0];
       if (!url) continue;
       const normalized = normalize(url);
-      if (!instances.has(normalized))
-        instances.set(normalized, {url: normalized, scope});
+      if (instances.has(normalized)) continue;
+
+      const instance: OverpassInstance = {url: normalized, scope};
+      const coverage = plainText(rowCells[coverageColumn] ?? "");
+      if (coverage) instance.coverage = coverage;
+      const usagePolicy = plainText(rowCells[usagePolicyColumn] ?? "");
+      if (usagePolicy) instance.usagePolicy = usagePolicy;
+      instances.set(normalized, instance);
     }
   }
 

--- a/js/overpass-servers.ts
+++ b/js/overpass-servers.ts
@@ -12,10 +12,21 @@
 // listed as `https://overpass.atownsend.org.uk/api/` without the suffix, and
 // the string also occurs in the prose outside of the tables.
 
-import {requestText} from "./httpRequest";
+import {requestJson} from "./httpRequest";
 
-const WIKI_URL =
-  "https://wiki.openstreetmap.org/w/index.php?title=Overpass_API&action=raw";
+// the wikitext is fetched via api.php rather than `action=raw`, because only
+// api.php answers with an `Access-Control-Allow-Origin` header (`origin=*`)
+const WIKI_URL = new URL("https://wiki.openstreetmap.org/w/api.php");
+WIKI_URL.search = new URLSearchParams({
+  action: "query",
+  prop: "revisions",
+  rvprop: "content",
+  rvslots: "main",
+  titles: "Overpass_API",
+  format: "json",
+  formatversion: "2",
+  origin: "*"
+}).toString();
 
 export interface OverpassInstance {
   /** API endpoint, normalized to a trailing slash and without `interpreter` */
@@ -76,7 +87,16 @@ export function parseInstances(wikitext: string): OverpassInstance[] {
   return [...instances.values()];
 }
 
+interface WikiResponse {
+  query?: {
+    pages?: {revisions?: {slots?: {main?: {content?: string}}}[]}[];
+  };
+}
+
 /** fetches the public Overpass API instances listed on the OSM wiki */
 export async function fetchInstances(): Promise<OverpassInstance[]> {
-  return parseInstances(await requestText(WIKI_URL));
+  const response = await requestJson<WikiResponse>(WIKI_URL);
+  const wikitext =
+    response.query?.pages?.[0]?.revisions?.[0]?.slots?.main?.content;
+  return wikitext ? parseInstances(wikitext) : [];
 }

--- a/js/overpass-servers.ts
+++ b/js/overpass-servers.ts
@@ -39,50 +39,6 @@ export interface OverpassInstance {
   usagePolicy?: string;
 }
 
-/** splits a wikitable row into its cells, dropping any `scope="col"` markup */
-function cells(row: string): string[] {
-  return row
-    .split(/^[!|]/m)
-    .slice(1)
-    .map((cell) =>
-      cell
-        .split(/^[!|]{2}/m)[0]
-        .replace(/^scope="col"\s*(width="[^"]*")?\s*\|/, "")
-        .trim()
-    );
-}
-
-/**
- * Turns `https://overpass-api.de/api/interpreter` into
- * `https://overpass-api.de/api/`, the form used in {@link configs.suggestedServers}.
- */
-function normalize(url: string): string {
-  return url.replace(/interpreter\/?$/, "").replace(/\/?$/, "/");
-}
-
-/**
- * Reduces the wikitext of a table cell to plain text: links keep their label
- * (external ones also their target), footnotes and templates are dropped.
- *
- * The result is deliberately text and not HTML — the wiki is world-writable,
- * so its markup must never end up in the DOM as markup.
- */
-function plainText(wikitext: string): string {
-  return wikitext
-    .replace(/<ref[^>]*\/>|<ref[^>]*>[\s\S]*?<\/ref>/g, "") // footnotes
-    .replace(/\[\[[^\]|]*\|([^\]]*)\]\]/g, "$1") // [[Page|label]]
-    .replace(/\[\[([^\]]*)\]\]/g, "$1") // [[Page]]
-    .replace(/\[(https?:\/\/\S+)\s+([^\]]*)\]/g, "$2 ($1)") // [url label]
-    .replace(/\[(https?:\/\/[^\]\s]+)\]/g, "$1") // [url]
-    .replace(/\{\{[Uu]ser\|([^|}]*)[^}]*\}\}/g, "$1") // {{User|name|…}}
-    .replace(/\{\{[^{}]*\}\}/g, "") // any other template
-    .replace(/<br\s*\/?>/gi, " ")
-    .replace(/<[^>]+>/g, "") // syntaxhighlight and friends
-    .replace(/'''?/g, "") // bold/italic
-    .replace(/\s+/g, " ")
-    .trim();
-}
-
 /** parses the instance tables out of the raw wikitext of the Overpass API page */
 export function parseInstances(wikitext: string): OverpassInstance[] {
   const instances = new Map<string, OverpassInstance>();
@@ -120,17 +76,57 @@ export function parseInstances(wikitext: string): OverpassInstance[] {
   }
 
   return [...instances.values()];
-}
 
-interface WikiResponse {
-  query?: {
-    pages?: {revisions?: {slots?: {main?: {content?: string}}}[]}[];
-  };
+  /** splits a wikitable row into its cells, dropping any `scope="col"` markup */
+  function cells(row: string): string[] {
+    return row
+      .split(/^[!|]/m)
+      .slice(1)
+      .map((cell) =>
+        cell
+          .split(/^[!|]{2}/m)[0]
+          .replace(/^scope="col"\s*(width="[^"]*")?\s*\|/, "")
+          .trim()
+      );
+  }
+
+  /**
+   * Turns `https://overpass-api.de/api/interpreter` into
+   * `https://overpass-api.de/api/`, the form used in {@link configs.suggestedServers}.
+   */
+  function normalize(url: string): string {
+    return url.replace(/interpreter\/?$/, "").replace(/\/?$/, "/");
+  }
+
+  /**
+   * Reduces the wikitext of a table cell to plain text: links keep their label
+   * (external ones also their target), footnotes and templates are dropped.
+   *
+   * The result is deliberately text and not HTML — the wiki is world-writable,
+   * so its markup must never end up in the DOM as markup.
+   */
+  function plainText(wikitext: string): string {
+    return wikitext
+      .replace(/<ref[^>]*\/>|<ref[^>]*>[\s\S]*?<\/ref>/g, "") // footnotes
+      .replace(/\[\[[^\]|]*\|([^\]]*)\]\]/g, "$1") // [[Page|label]]
+      .replace(/\[\[([^\]]*)\]\]/g, "$1") // [[Page]]
+      .replace(/\[(https?:\/\/\S+)\s+([^\]]*)\]/g, "$2 ($1)") // [url label]
+      .replace(/\[(https?:\/\/[^\]\s]+)\]/g, "$1") // [url]
+      .replace(/\{\{[Uu]ser\|([^|}]*)[^}]*\}\}/g, "$1") // {{User|name|…}}
+      .replace(/\{\{[^{}]*\}\}/g, "") // any other template
+      .replace(/<br\s*\/?>/gi, " ")
+      .replace(/<[^>]+>/g, "") // syntaxhighlight and friends
+      .replace(/'''?/g, "") // bold/italic
+      .replace(/\s+/g, " ")
+      .trim();
+  }
 }
 
 /** fetches the public Overpass API instances listed on the OSM wiki */
 export async function fetchInstances(): Promise<OverpassInstance[]> {
-  const response = await requestJson<WikiResponse>(WIKI_URL);
+  const response = await requestJson<{
+    query?: {pages?: {revisions?: {slots?: {main?: {content?: string}}}[]}[]};
+  }>(WIKI_URL);
   const wikitext =
     response.query?.pages?.[0]?.revisions?.[0]?.slots?.main?.content;
   return wikitext ? parseInstances(wikitext) : [];

--- a/js/overpass-servers.ts
+++ b/js/overpass-servers.ts
@@ -1,0 +1,82 @@
+// Extracts the list of public Overpass API instances from the OSM wiki.
+//
+// The wiki page lists the instances in two tables ("Instances with global data
+// coverage" and "Instances with data only for a specific region"). Rather than
+// keying off the section headings or the column order — both of which change
+// with routine edits — the parser relies on two structural properties:
+//
+//  - the instance tables are the only wikitables with an "API Endpoint" column
+//  - only the regional table has a "Data coverage" column
+//
+// Grepping the page for `/api/interpreter` does not work: one instance is
+// listed as `https://overpass.atownsend.org.uk/api/` without the suffix, and
+// the string also occurs in the prose outside of the tables.
+
+import {requestText} from "./httpRequest";
+
+const WIKI_URL =
+  "https://wiki.openstreetmap.org/w/index.php?title=Overpass_API&action=raw";
+
+export interface OverpassInstance {
+  /** API endpoint, normalized to a trailing slash and without `interpreter` */
+  url: string;
+  /** whether the instance serves the whole planet or only a single region */
+  scope: "global" | "regional";
+}
+
+/** splits a wikitable row into its cells, dropping any `scope="col"` markup */
+function cells(row: string): string[] {
+  return row
+    .split(/^[!|]/m)
+    .slice(1)
+    .map((cell) =>
+      cell
+        .split(/^[!|]{2}/m)[0]
+        .replace(/^scope="col"\s*(width="[^"]*")?\s*\|/, "")
+        .trim()
+    );
+}
+
+/**
+ * Turns `https://overpass-api.de/api/interpreter` into
+ * `https://overpass-api.de/api/`, the form used in {@link configs.suggestedServers}.
+ */
+function normalize(url: string): string {
+  return url.replace(/interpreter\/?$/, "").replace(/\/?$/, "/");
+}
+
+/** parses the instance tables out of the raw wikitext of the Overpass API page */
+export function parseInstances(wikitext: string): OverpassInstance[] {
+  const instances = new Map<string, OverpassInstance>();
+
+  for (const table of wikitext.match(/^\{\|[\s\S]*?^\|\}/gm) ?? []) {
+    const rows = table
+      .split(/^\|-.*$/m)
+      .map((row) => row.replace(/^\{\|.*$|^\|\}$/gm, "").trim())
+      .filter(Boolean);
+    if (!rows.length) continue;
+
+    const headers = cells(rows[0]);
+    const endpointColumn = headers.findIndex((h) => /API Endpoint/i.test(h));
+    if (endpointColumn === -1) continue; // not an instance table
+    const scope = headers.some((h) => /Data coverage/i.test(h))
+      ? "regional"
+      : "global";
+
+    for (const row of rows.slice(1)) {
+      const cell = cells(row)[endpointColumn];
+      const url = cell?.replace(/<[^>]+>/g, "").match(/https?:\/\/\S+/)?.[0];
+      if (!url) continue;
+      const normalized = normalize(url);
+      if (!instances.has(normalized))
+        instances.set(normalized, {url: normalized, scope});
+    }
+  }
+
+  return [...instances.values()];
+}
+
+/** fetches the public Overpass API instances listed on the OSM wiki */
+export async function fetchInstances(): Promise<OverpassInstance[]> {
+  return parseInstances(await requestText(WIKI_URL));
+}

--- a/locales/en.json
+++ b/locales/en.json
@@ -42,6 +42,7 @@
   "settings.theme.dark": "dark",
   "settings.theme_expl": "\"automatic\" follows your system's color scheme.",
   "settings.server": "Server",
+  "settings.server_coverage": "Data coverage",
   "settings.disable_autorepair": "Disable warning/autorepair message when Overpass API returns no visible data.",
   "settings.disable_warning_huge_data": "Disable warning when Overpass API returns large amounts of data.",
   "settings.section.editor": "Editor",

--- a/tests/test.overpass-servers.ts
+++ b/tests/test.overpass-servers.ts
@@ -1,0 +1,137 @@
+import {beforeEach, describe, expect, it, vi} from "vite-plus/test";
+
+import {requestText} from "../js/httpRequest";
+import {fetchInstances, parseInstances} from "../js/overpass-servers";
+
+vi.mock("../js/httpRequest", () => ({requestText: vi.fn()}));
+
+// an excerpt of https://wiki.openstreetmap.org/wiki/Overpass_API, including a
+// decoy table without an "API Endpoint" column and prose mentioning
+// `interpreter` outside of the tables
+const WIKITEXT = `== Public Overpass API instances==
+{{Note|Important: do not add <syntaxhighlight inline lang="">interpreter</syntaxhighlight>, Turbo does this automatically.}}
+
+{| class="wikitable"
+|-
+! scope="col" |Language
+! scope="col" |Library
+|-
+|Python
+|overpy
+|}
+
+=== Instances with global data coverage ===
+
+{| class="wikitable"
+|-
+! scope="col" |Name
+! scope="col" |API Endpoint
+! scope="col" |[[Attic Data|Attic data]]
+! scope="col" width="40%" |Usage policy
+|-
+|[https://overpass-api.de/ Main Overpass API instance]
+|<syntaxhighlight inline lang="">https://overpass-api.de/api/interpreter</syntaxhighlight>
+| {{yes}}
+|Less than 10,000 queries per day.
+|-
+|[https://www.geofabrik.de/data/overpass-api.html Geofabrik Overpass]
+|<syntaxhighlight inline lang="">https://overpass.geofabrik.de/YOUR_API_KEY/api/interpreter</syntaxhighlight>
+| {{no}}
+|[https://www.geofabrik.de/data/overpass-api.html Payment required]
+|}
+
+=== Instances with data only for a specific region ===
+
+{| class="wikitable"
+|-
+! scope="col" |Name
+! scope="col" |Data coverage
+! scope="col" |API Endpoint
+! scope="col" |Hardware
+|-
+|[https://overpass.osm.ch/ Swiss Overpass API instance]
+|Switzerland
+|<syntaxhighlight inline lang="">https://overpass.osm.ch/api/interpreter</syntaxhighlight>
+|12 cores, 64 GB RAM
+|-
+|[https://overpass.atownsend.org.uk/ Britain and Ireland Overpass Instance]
+|Britain and Ireland
+|<syntaxhighlight inline lang="">https://overpass.atownsend.org.uk/api/</syntaxhighlight>
+|1 VM, 4 cores
+|}
+`;
+
+describe("overpass-servers", () => {
+  beforeEach(() => {
+    vi.mocked(requestText).mockReset();
+  });
+
+  it("fetches the wiki page as raw wikitext", async () => {
+    vi.mocked(requestText).mockResolvedValue(WIKITEXT);
+    await fetchInstances();
+    expect(requestText).toHaveBeenCalledWith(
+      "https://wiki.openstreetmap.org/w/index.php?title=Overpass_API&action=raw"
+    );
+  });
+
+  it("parses both instance tables", async () => {
+    vi.mocked(requestText).mockResolvedValue(WIKITEXT);
+    expect(await fetchInstances()).toEqual([
+      {url: "https://overpass-api.de/api/", scope: "global"},
+      {url: "https://overpass.geofabrik.de/YOUR_API_KEY/api/", scope: "global"},
+      {url: "https://overpass.osm.ch/api/", scope: "regional"},
+      {url: "https://overpass.atownsend.org.uk/api/", scope: "regional"}
+    ]);
+  });
+
+  it("ignores tables without an API Endpoint column", () => {
+    expect(
+      parseInstances(`{| class="wikitable"
+|-
+! scope="col" |Name
+! scope="col" |Homepage
+|-
+|Main instance
+|https://overpass-api.de/
+|}`)
+    ).toEqual([]);
+  });
+
+  it("finds the endpoint column regardless of its position", () => {
+    expect(
+      parseInstances(`{| class="wikitable"
+|-
+! scope="col" |API Endpoint
+! scope="col" |Name
+|-
+|https://overpass-api.de/api/interpreter
+|Main instance
+|}`)
+    ).toEqual([{url: "https://overpass-api.de/api/", scope: "global"}]);
+  });
+
+  it("does not depend on the section headings", () => {
+    // with both headings renamed, only the "Data coverage" column still
+    // distinguishes the regional from the global table
+    const renamed = WIKITEXT.replace(/^=== .* ===$/gm, "=== Instances ===");
+    expect(parseInstances(renamed).map((i) => i.scope)).toEqual([
+      "global",
+      "global",
+      "regional",
+      "regional"
+    ]);
+  });
+
+  it("deduplicates repeated endpoints", () => {
+    expect(
+      parseInstances(`{| class="wikitable"
+|-
+! scope="col" |API Endpoint
+|-
+|https://overpass-api.de/api/interpreter
+|-
+|https://overpass-api.de/api/
+|}`)
+    ).toEqual([{url: "https://overpass-api.de/api/", scope: "global"}]);
+  });
+});

--- a/tests/test.overpass-servers.ts
+++ b/tests/test.overpass-servers.ts
@@ -1,9 +1,14 @@
 import {beforeEach, describe, expect, it, vi} from "vite-plus/test";
 
-import {requestText} from "../js/httpRequest";
+import {requestJson} from "../js/httpRequest";
 import {fetchInstances, parseInstances} from "../js/overpass-servers";
 
-vi.mock("../js/httpRequest", () => ({requestText: vi.fn()}));
+vi.mock("../js/httpRequest", () => ({requestJson: vi.fn()}));
+
+/** wraps wikitext the way the MediaWiki API returns it */
+const apiResponse = (wikitext: string) => ({
+  query: {pages: [{revisions: [{slots: {main: {content: wikitext}}}]}]}
+});
 
 // an excerpt of https://wiki.openstreetmap.org/wiki/Overpass_API, including a
 // decoy table without an "API Endpoint" column and prose mentioning
@@ -63,19 +68,34 @@ const WIKITEXT = `== Public Overpass API instances==
 
 describe("overpass-servers", () => {
   beforeEach(() => {
-    vi.mocked(requestText).mockReset();
+    vi.mocked(requestJson).mockReset();
   });
 
-  it("fetches the wiki page as raw wikitext", async () => {
-    vi.mocked(requestText).mockResolvedValue(WIKITEXT);
+  it("requests the wikitext through the CORS-enabled api.php", async () => {
+    vi.mocked(requestJson).mockResolvedValue(apiResponse(WIKITEXT));
     await fetchInstances();
-    expect(requestText).toHaveBeenCalledWith(
-      "https://wiki.openstreetmap.org/w/index.php?title=Overpass_API&action=raw"
+    const url = vi.mocked(requestJson).mock.calls[0][0] as URL;
+    expect(url.origin + url.pathname).toBe(
+      "https://wiki.openstreetmap.org/w/api.php"
     );
+    expect(Object.fromEntries(url.searchParams)).toMatchObject({
+      action: "query",
+      prop: "revisions",
+      rvprop: "content",
+      rvslots: "main",
+      titles: "Overpass_API",
+      // must stay a literal `*`, percent-encoding it breaks the CORS handshake
+      origin: "*"
+    });
+  });
+
+  it("returns no instances when the page has no content", async () => {
+    vi.mocked(requestJson).mockResolvedValue({});
+    expect(await fetchInstances()).toEqual([]);
   });
 
   it("parses both instance tables", async () => {
-    vi.mocked(requestText).mockResolvedValue(WIKITEXT);
+    vi.mocked(requestJson).mockResolvedValue(apiResponse(WIKITEXT));
     expect(await fetchInstances()).toEqual([
       {url: "https://overpass-api.de/api/", scope: "global"},
       {url: "https://overpass.geofabrik.de/YOUR_API_KEY/api/", scope: "global"},

--- a/tests/test.overpass-servers.ts
+++ b/tests/test.overpass-servers.ts
@@ -37,7 +37,7 @@ const WIKITEXT = `== Public Overpass API instances==
 |[https://overpass-api.de/ Main Overpass API instance]
 |<syntaxhighlight inline lang="">https://overpass-api.de/api/interpreter</syntaxhighlight>
 | {{yes}}
-|Less than 10,000 queries per day.
+|Less than 10,000 queries per day<ref>https://dev.overpass-api.de/</ref>.<br />Be sure to send a <syntaxhighlight inline lang="">User-Agent</syntaxhighlight> header. Ask [[User:Roland]] or {{User|someone|wiki=Someone}}.
 |-
 |[https://www.geofabrik.de/data/overpass-api.html Geofabrik Overpass]
 |<syntaxhighlight inline lang="">https://overpass.geofabrik.de/YOUR_API_KEY/api/interpreter</syntaxhighlight>
@@ -97,11 +97,45 @@ describe("overpass-servers", () => {
   it("parses both instance tables", async () => {
     vi.mocked(requestJson).mockResolvedValue(apiResponse(WIKITEXT));
     expect(await fetchInstances()).toEqual([
-      {url: "https://overpass-api.de/api/", scope: "global"},
-      {url: "https://overpass.geofabrik.de/YOUR_API_KEY/api/", scope: "global"},
-      {url: "https://overpass.osm.ch/api/", scope: "regional"},
-      {url: "https://overpass.atownsend.org.uk/api/", scope: "regional"}
+      {
+        url: "https://overpass-api.de/api/",
+        scope: "global",
+        // footnote, templates and markup gone, link labels kept
+        usagePolicy:
+          "Less than 10,000 queries per day. Be sure to send a User-Agent header. Ask User:Roland or someone."
+      },
+      {
+        url: "https://overpass.geofabrik.de/YOUR_API_KEY/api/",
+        scope: "global",
+        usagePolicy:
+          "Payment required (https://www.geofabrik.de/data/overpass-api.html)"
+      },
+      // the regional table of the fixture has no usage policy column
+      {
+        url: "https://overpass.osm.ch/api/",
+        scope: "regional",
+        coverage: "Switzerland"
+      },
+      {
+        url: "https://overpass.atownsend.org.uk/api/",
+        scope: "regional",
+        coverage: "Britain and Ireland"
+      }
     ]);
+  });
+
+  it("strips markup from the usage policy", () => {
+    // anybody can edit the wiki, so no markup may survive into the result
+    const [instance] = parseInstances(`{| class="wikitable"
+|-
+! scope="col" |API Endpoint
+! scope="col" |Usage policy
+|-
+|https://overpass-api.de/api/
+|<script>alert(1)</script><img src=x onerror=alert(1)/> Be '''nice'''.
+|}`);
+    expect(instance.usagePolicy).toBe("alert(1) Be nice.");
+    expect(instance.usagePolicy).not.toMatch(/[<>]/);
   });
 
   it("ignores tables without an API Endpoint column", () => {


### PR DESCRIPTION
Extracts the API endpoints from the two instance tables on
https://wiki.openstreetmap.org/wiki/Overpass_API.

<img width="882" height="589" alt="image" src="https://github.com/user-attachments/assets/f9ebd462-fff0-4e24-97d8-b50bb1133496" />
