### PR TITLE
Make the codebase type-check, and keep it that way

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,7 +12,7 @@
   "[typescriptreact]": {
     "editor.defaultFormatter": "oxc.oxc-vscode"
   },
-  "oxc.fmt.configPath": "./vite.config.ts",
+  "oxc.fmt.configPath": "./vite.config.mts",
   "editor.formatOnSave": true,
   "editor.formatOnSaveMode": "file",
   "editor.codeActionsOnSave": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ These changes are live on the development instance at <https://tyrasd.github.io/
 - Fix selection of combobox in autostyler dialog
 - Fix missing `attribution` control object, which is required for PNG export ([#813](https://github.com/tyrasd/overpass-turbo/issues/813))
 - Fix "L is not defined" in production build
+- Rewrite the MapCSS style parser as ES6 classes, keeping selector matching, property assignment and style merging as they were ([#857](https://github.com/tyrasd/overpass-turbo/pull/857))
+- Type-check the whole codebase, on TypeScript 6 with `strict` enabled, and check it in CI ([#857](https://github.com/tyrasd/overpass-turbo/pull/857))
 
 ## 2024-11-03
 

--- a/js/GeoJsonNoVanish.ts
+++ b/js/GeoJsonNoVanish.ts
@@ -1,7 +1,11 @@
 import * as L from "leaflet";
 
-/** How a feature should be rendered, as decided by the MapCSS `render` property. */
-type Compress = "auto" | "native" | "point" | undefined;
+/**
+ * How a feature should be drawn, as decided by the MapCSS `render` property:
+ * `auto` lets it be replaced by a point when small, `native` always keeps its
+ * own geometry, and `point` always draws it as a point.
+ */
+export type RenderMode = "auto" | "native" | "point";
 
 /** A GeoJSON feature, plus the marker set on the stand-ins created below. */
 type PlaceholderFeature = GeoJSON.Feature & {is_placeholder?: boolean};
@@ -25,7 +29,7 @@ interface FeatureLayer extends L.Layer {
 interface Options extends L.GeoJSONOptions {
   /** Features smaller than this many pixels across are drawn as a point. */
   threshold?: number;
-  compress?: (feature: PlaceholderFeature) => Compress;
+  compress?: (feature: PlaceholderFeature) => RenderMode | undefined;
 }
 
 /**

--- a/js/GeoJsonNoVanish.ts
+++ b/js/GeoJsonNoVanish.ts
@@ -1,12 +1,47 @@
 import * as L from "leaflet";
 
+/** How a feature should be rendered, as decided by the MapCSS `render` property. */
+type Compress = "auto" | "native" | "point" | undefined;
+
+/** A GeoJSON feature, plus the marker set on the stand-ins created below. */
+type PlaceholderFeature = GeoJSON.Feature & {is_placeholder?: boolean};
+
+/**
+ * A layer rendered from a GeoJSON feature, plus the links this module hangs
+ * off it to pair a feature with the point standing in for it.
+ */
+interface FeatureLayer extends L.Layer {
+  feature?: PlaceholderFeature;
+  /** On a stand-in, the layer whose geometry it replaces. */
+  obj?: FeatureLayer;
+  /** On a replaced layer, the stand-in currently drawn for it. */
+  placeholder?: FeatureLayer;
+  _tooltip?: L.Tooltip;
+  options: L.PathOptions;
+  getBounds(): L.LatLngBounds;
+  getCenter(): L.LatLng;
+}
+
+interface Options extends L.GeoJSONOptions {
+  /** Features smaller than this many pixels across are drawn as a point. */
+  threshold?: number;
+  compress?: (feature: PlaceholderFeature) => Compress;
+}
+
+/**
+ * A GeoJSON layer that replaces features too small to see at the current zoom
+ * with a point, so that they do not vanish, and restores their real geometry
+ * once zoomed in far enough.
+ */
 class GeoJsonNoVanish extends L.GeoJSON {
   threshold = 10;
-  constructor(geojson, options) {
+  declare options: Options;
+
+  constructor(geojson, options: Options) {
     super(geojson, options);
     this.threshold = options?.threshold ?? 10;
   }
-  onAdd(map) {
+  override onAdd(map: L.Map): this {
     this._map = map;
     this.eachLayer(map.addLayer, map);
 
@@ -14,32 +49,39 @@ class GeoJsonNoVanish extends L.GeoJSON {
     this._onZoomEnd();
     return this;
   }
-  onRemove(map) {
+  override onRemove(map: L.Map): this {
     this._map.removeEventListener("zoomend", this._onZoomEnd, this);
 
     this.eachLayer(map.removeLayer, map);
     this._map = null;
     return this;
   }
+
+  /** The size of a layer's bounding box, in squared pixels at the current zoom. */
+  private _sizeOnScreen(bounds: L.LatLngBounds): number {
+    const crs = this._map.options.crs;
+    const zoom = this._map.getZoom();
+    const p1 = crs.latLngToPoint(bounds.getSouthWest(), zoom);
+    const p2 = crs.latLngToPoint(bounds.getNorthEast(), zoom);
+    return Math.pow(p1.x - p2.x, 2) + Math.pow(p1.y - p2.y, 2);
+  }
+
   _onZoomEnd() {
     // todo: name
     // todo: possible optimizations: zoomOut = skip already compressed objects (and vice versa)
     const is_max_zoom = this._map.getZoom() == this._map.getMaxZoom();
-    this.eachLayer(function (o) {
+    const threshold = Math.pow(this.threshold, 2);
+    this.eachLayer((layer) => {
+      const o = layer as FeatureLayer;
       if (!o.feature || !o.feature.geometry) return; // skip invalid layers
       if (o.feature.geometry.type == "Point" && !o.obj) return; // skip node features
       const compress =
         this.options.compress &&
         this.options.compress(o.obj ? o.obj.feature : o.feature);
-      const crs = this._map.options.crs;
       if (o.obj) {
         if (compress === "point") return;
         // already compressed feature
-        const bounds = o.obj.getBounds();
-        const p1 = crs.latLngToPoint(bounds.getSouthWest(), o._map.getZoom());
-        const p2 = crs.latLngToPoint(bounds.getNorthEast(), o._map.getZoom());
-        const d = Math.pow(p1.x - p2.x, 2) + Math.pow(p1.y - p2.y, 2);
-        if (d > Math.pow(this.threshold, 2) || is_max_zoom) {
+        if (this._sizeOnScreen(o.obj.getBounds()) > threshold || is_max_zoom) {
           delete o.obj.placeholder;
           this.removeLayer(o);
           if (o._tooltip) {
@@ -52,28 +94,23 @@ class GeoJsonNoVanish extends L.GeoJSON {
       if (is_max_zoom && compress !== "point") return; // do not compress objects at max zoom, except if mapcss says always to render as points
       if (compress === "native") return; // do not compress if mapcss specifies not to
       const bounds = o.getBounds();
-      const p1 = crs.latLngToPoint(bounds.getSouthWest(), o._map.getZoom());
-      const p2 = crs.latLngToPoint(bounds.getNorthEast(), o._map.getZoom());
-      const d = Math.pow(p1.x - p2.x, 2) + Math.pow(p1.y - p2.y, 2);
-      if (d > Math.pow(this.threshold, 2) && compress !== "point") return;
-      let center;
-      if (d <= Math.pow(this.threshold, 2)) {
-        center = bounds.getCenter();
-      } else {
-        center = o.getCenter();
-      }
-      const f = L.extend({}, o.feature);
-      f.is_placeholder = true;
-      f.geometry = {
-        type: "Point",
-        coordinates: [center.lng, center.lat]
+      const d = this._sizeOnScreen(bounds);
+      if (d > threshold && compress !== "point") return;
+      const center = d <= threshold ? bounds.getCenter() : o.getCenter();
+      const f: PlaceholderFeature = {
+        ...o.feature,
+        is_placeholder: true,
+        geometry: {
+          type: "Point",
+          coordinates: [center.lng, center.lat]
+        }
       };
-      const c = L.GeoJSON.geometryToLayer(f, this.options);
+      const c = L.GeoJSON.geometryToLayer(f, this.options) as FeatureLayer;
       o.placeholder = c;
       c.feature = f;
       c.obj = o;
-      c.on("click", function (e) {
-        this.obj.fireEvent(e.type, e);
+      c.on("click", (e) => {
+        o.fire(e.type, e);
       });
       this.removeLayer(o);
       this.resetStyle(c);
@@ -84,7 +121,7 @@ class GeoJsonNoVanish extends L.GeoJSON {
         c.bindTooltip(o._tooltip);
       }
       this.addLayer(c);
-    }, this);
+    });
   }
 }
 

--- a/js/GeoJsonNoVanish.ts
+++ b/js/GeoJsonNoVanish.ts
@@ -1,4 +1,4 @@
-import "leaflet";
+import * as L from "leaflet";
 
 class GeoJsonNoVanish extends L.GeoJSON {
   threshold = 10;

--- a/js/OSM4Leaflet.ts
+++ b/js/OSM4Leaflet.ts
@@ -1,4 +1,4 @@
-import "leaflet";
+import * as L from "leaflet";
 import osmtogeojson from "osmtogeojson";
 
 type Options = {

--- a/js/OSM4Leaflet.ts
+++ b/js/OSM4Leaflet.ts
@@ -1,18 +1,18 @@
 import * as L from "leaflet";
 import osmtogeojson from "osmtogeojson";
 
-type Options = {
-  data_mode: string;
+interface Options extends L.LayerOptions {
+  /** The GeoJSON layer class to render the result with. */
   baseLayerClass: typeof L.GeoJSON;
   baseLayerOptions: L.GeoJSONOptions;
+  /** Invoked once the result has been converted to GeoJSON. */
   afterParse?: () => void;
-};
+}
 
 class OSM4Leaflet extends L.Layer {
   private _resultData: GeoJSON.FeatureCollection;
   private _baseLayer: L.GeoJSON;
-  private options: Options = {
-    data_mode: "xml",
+  options: Options = {
     baseLayerClass: L.GeoJSON,
     baseLayerOptions: {}
   };

--- a/js/PopupIcon.ts
+++ b/js/PopupIcon.ts
@@ -15,7 +15,8 @@ const PopupIcon = L.Icon.extend({
   },
 
   initialize(text, options) {
-    L.Icon.prototype.initialize.call(this, options);
+    // what L.Icon's own initialize does, and all it does
+    L.Util.setOptions(this, options);
     this._text = text;
   },
 

--- a/js/PopupIcon.ts
+++ b/js/PopupIcon.ts
@@ -5,7 +5,7 @@
  * @license WTFPL
  * @see github.com/MapBBCode/mapbbcode
  */
-import "leaflet";
+import * as L from "leaflet";
 
 const PopupIcon = L.Icon.extend({
   options: {

--- a/js/autorepair.ts
+++ b/js/autorepair.ts
@@ -2,49 +2,53 @@
 import $ from "jquery";
 
 import {Base64} from "./misc";
+import type {QueryLang} from "./overpass";
 
-export default function autorepair(q, lng) {
-  const repair = {};
+/**
+ * Repairs obvious mistakes in a query, such as a missing recurse statement or
+ * an output format the OSM editors cannot consume.
+ *
+ * Each repair rewrites the query held by the instance, so several can be
+ * applied in turn before reading the result back with {@link getQuery}.
+ */
+export default class Autorepair {
+  /**
+   * The comments of the original query, keyed by the placeholder standing in
+   * for them, so that commented-out code is not itself repaired.
+   */
+  private readonly comments: Record<string, string> = {};
 
-  const comments = {};
-
-  (function init() {
-    // replace comments with placeholders
-    // (we do not want to autorepair stuff which is commented out.)
-    let cs, placeholder;
-    if (lng == "xml") {
-      cs = q.match(/<!--[\s\S]*?-->/g) || [];
-      for (const csi of cs) {
-        placeholder = `<!--${Base64.encode(Math.random().toString())}-->`; //todo: use some kind of checksum or hash maybe?
-        q = q.replace(csi, placeholder);
-        comments[placeholder] = csi;
-      }
-    } else {
-      cs = q.match(/\/\*[\s\S]*?\*\//g) || []; // multiline comments: /*...*/
-      for (const csi of cs) {
-        placeholder = `/*${Base64.encode(Math.random().toString())}*/`; //todo: use some kind of checksum or hash maybe?
-        q = q.replace(csi, placeholder);
-        comments[placeholder] = csi;
-      }
-      cs = q.match(/\/\/[^\n]*/g) || []; // single line comments: //...
-      for (const csi of cs) {
-        placeholder = `/*${Base64.encode(Math.random().toString())}*/`; //todo: use some kind of checksum or hash maybe?
-        q = q.replace(csi, placeholder);
-        comments[placeholder] = csi;
+  constructor(
+    private query: string,
+    private readonly lng: QueryLang
+  ) {
+    const pattern =
+      lng == "xml"
+        ? [/<!--[\s\S]*?-->/g] // <!--...-->
+        : [/\/\*[\s\S]*?\*\//g, /\/\/[^\n]*/g]; // /*...*/ and //...
+    for (const comments of pattern) {
+      for (const comment of this.query.match(comments) || []) {
+        //todo: use some kind of checksum or hash maybe?
+        const token = Base64.encode(Math.random().toString());
+        const placeholder = lng == "xml" ? `<!--${token}-->` : `/*${token}*/`;
+        this.query = this.query.replace(comment, placeholder);
+        this.comments[placeholder] = comment;
       }
     }
-  })();
+  }
 
-  repair.getQuery = () => {
-    // expand placeholded comments
-    for (const placeholder in comments) {
-      q = q.replace(placeholder, comments[placeholder]);
+  /** The query, with the repairs applied and its comments restored. */
+  getQuery(): string {
+    for (const placeholder in this.comments) {
+      this.query = this.query.replace(placeholder, this.comments[placeholder]);
     }
-    return q;
-  };
+    return this.query;
+  }
 
-  repair.recurse = () => {
-    if (lng == "xml") {
+  /** Makes each output statement also output the elements it references. */
+  recurse(): boolean {
+    let q = this.query;
+    if (this.lng == "xml") {
       // do some fancy mixture between regex magic and xml as html parsing :€
       const prints =
         q.match(/(\n?[^\S\n]*<print[\s\S]*?(\/>|<\/print>))/g) || [];
@@ -84,11 +88,14 @@ export default function autorepair(q, lng) {
       for (let i = 0; i < outs.length; i++)
         q = q.replace(`<autorepair>${i}</autorepair>`, outs[i]);
     }
+    this.query = q;
     return true;
-  };
+  }
 
-  repair.editors = () => {
-    if (lng == "xml") {
+  /** Rewrites the query to the output format the OSM editors can consume. */
+  editors(): boolean {
+    let q = this.query;
+    if (this.lng == "xml") {
       // 1. fix <osm-script output=*
       const src = q.match(/<osm-script([^>]*)>/);
       if (src) {
@@ -174,49 +181,49 @@ export default function autorepair(q, lng) {
           q = q.replace(print, `${new_print}/*fixed by auto repair*/`);
       }
     }
+    this.query = q;
     return true;
-  };
-
-  return repair;
-}
-
-autorepair.detect = {};
-autorepair.detect.editors = (q, lng) => {
-  // todo: test this
-  // todo: move into autorepair "module" /// todo. done?
-  q = q.replace(/{{.*?}}/g, "");
-  const err = {};
-  if (lng == "xml") {
-    try {
-      const xml = $.parseXML(`<x>${q}</x>`);
-      const out = $("osm-script", xml).attr("output");
-      if (out !== undefined && out !== "xml") err.output = true;
-      $("print", xml).each((i, p) => {
-        if ($(p).attr("mode") !== "meta") err.meta = true;
-      });
-      $("print", xml).each((i, p) => {
-        if (
-          $(p)
-            .attr("geometry")
-            .match(/(center|bounds|full)/)
-        )
-          err.geometry = true;
-      });
-    } catch {} // ignore xml syntax errors ?!
-  } else {
-    // ignore comments
-    q = q.replace(/\/\*[\s\S]*?\*\//g, "");
-    q = q.replace(/\/\/[^\n]*/g, "");
-    const out = q.match(/\[\s*out\s*:\s*([^\]\s]+)\s*\]/);
-    if (out && out[1] != "xml") err.output = true;
-    const prints = q.match(/out([^:;]*);/g);
-    prints?.forEach((p) => {
-      if (p.match(/\s(body|skel|ids|tags)/) || !p.match(/meta/))
-        err.meta = true;
-    });
-    prints?.forEach((p) => {
-      if (p.match(/\s(center|bb|geom)/)) err.geometry = true;
-    });
   }
-  return Object.keys(err).length === 0;
-};
+
+  /**
+   * Whether a query already produces output the OSM editors can consume, and
+   * so needs no repair by {@link editors}. The two belong together: this must
+   * report exactly the problems that one fixes.
+   *
+   * It is static, and strips comments rather than masking them the way the
+   * constructor does, because it only inspects a query — nothing is written
+   * back, so the comments just have to be kept from matching.
+   */
+  // todo: test this
+  static isEditorCompatible(q: string, lng: QueryLang): boolean {
+    q = q.replace(/{{.*?}}/g, ""); // ignore shortcuts
+    if (lng == "xml") {
+      try {
+        const xml = $.parseXML(`<x>${q}</x>`);
+        const output = $("osm-script", xml).attr("output");
+        if (output !== undefined && output !== "xml") return false;
+        const prints = $("print", xml).toArray();
+        if (prints.some((p) => $(p).attr("mode") !== "meta")) return false;
+        if (
+          prints.some((p) =>
+            $(p)
+              .attr("geometry")
+              .match(/(center|bounds|full)/)
+          )
+        )
+          return false;
+      } catch {} // ignore xml syntax errors ?!
+      return true;
+    }
+    // ignore comments
+    q = q.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/[^\n]*/g, "");
+    const out = q.match(/\[\s*out\s*:\s*([^\]\s]+)\s*\]/);
+    if (out && out[1] != "xml") return false;
+    const prints = q.match(/out([^:;]*);/g) || [];
+    if (
+      prints.some((p) => p.match(/\s(body|skel|ids|tags)/) || !p.match(/meta/))
+    )
+      return false;
+    return !prints.some((p) => p.match(/\s(center|bb|geom)/));
+  }
+}

--- a/js/configs.ts
+++ b/js/configs.ts
@@ -1,3 +1,5 @@
+import type {OSMAuthOptions} from "osm-auth";
+
 export default {
   appname: "overpass-turbo",
   // used for localStorage and openstreetmap.org/api/0.6/user/preferences
@@ -40,5 +42,5 @@ export default {
   osmAuth: {
     url: "https://www.openstreetmap.org",
     client_id: "lIifli2M7Enpi1LUqCxSNe3yDXhBHwf_n8HzJ03mKFg"
-  }
+  } as Partial<OSMAuthOptions>
 };

--- a/js/ffs.ts
+++ b/js/ffs.ts
@@ -21,9 +21,6 @@ type Condition = {
   free?: string;
 };
 
-/** a value to be quoted for use inside a regular expression */
-type RegexValue = {regex: string; modifier?: string};
-
 /* this converts a random boolean expression into a normalized form:
  * A∧B∧… ∨ C∧D∧… ∨ …
  * for example: A∧(B∨C) ⇔ (A∧B)∨(A∧C)
@@ -262,67 +259,6 @@ export async function ffs_construct_query(
         return false;
     }
   }
-  function get_query_clause_str(condition: Condition): string {
-    function quotes(s: string): string {
-      if (s.match(/^[a-zA-Z0-9_]+$/) === null)
-        return `"${s.replace(/"/g, '\\"')}"`;
-      return s;
-    }
-    function quoteRegex(s: RegexValue): string {
-      if (s.regex.match(/^[a-zA-Z0-9_]+$/) === null || s.modifier)
-        return `/${s.regex.replace(/\//g, "\\/")}/${s.modifier || ""}`;
-      return s.regex;
-    }
-    switch (condition.query) {
-      case "key":
-        return quote_comment_str(`${quotes(condition.key)}=*`);
-      case "nokey":
-        return quote_comment_str(`${quotes(condition.key)}!=*`);
-      case "eq":
-        return quote_comment_str(
-          `${quotes(condition.key)}=${quotes(condition.val)}`
-        );
-      case "neq":
-        return quote_comment_str(
-          `${quotes(condition.key)}!=${quotes(condition.val)}`
-        );
-      case "like":
-        return quote_comment_str(
-          `${quotes(condition.key)}~${quoteRegex(condition.val)}`
-        );
-      case "likelike":
-        return quote_comment_str(
-          `~${quotes(condition.key)}~${quoteRegex(condition.val)}`
-        );
-      case "notlike":
-        return quote_comment_str(
-          `${quotes(condition.key)}!~${quoteRegex(condition.val)}`
-        );
-      case "substr":
-        return quote_comment_str(
-          `${quotes(condition.key)}:${quotes(condition.val)}`
-        );
-      case "meta":
-        switch (condition.meta) {
-          case "id":
-            return quote_comment_str(`id:${quotes(condition.val)}`);
-          case "newer":
-            return quote_comment_str(`newer:${quotes(condition.val)}`);
-          case "older":
-            return quote_comment_str(`older:${quotes(condition.val)}`);
-          case "user":
-            return quote_comment_str(`user:${quotes(condition.val)}`);
-          case "uid":
-            return quote_comment_str(`uid:${quotes(condition.val)}`);
-          default:
-            return "";
-        }
-      case "free form":
-        return quote_comment_str(quotes(condition.free));
-      default:
-        return "";
-    }
-  }
 
   let freeForm = false;
   for (const and_query of ffs.query.queries) {
@@ -342,7 +278,6 @@ export async function ffs_construct_query(
   for (const and_query of ffs.query.queries) {
     let types = ["node", "way", "relation"];
     let clauses = [];
-    let clauses_str = [];
     for (const cond_query of and_query.queries) {
       // todo: looks like some code duplication here could be reduced by refactoring
       if (cond_query.query === "free form") {
@@ -351,7 +286,6 @@ export async function ffs_construct_query(
         // restrict possible data types
         types = types.filter((t) => ffs_clause.types.indexOf(t) != -1);
         // add clauses
-        clauses_str.push(get_query_clause_str(cond_query));
         clauses = clauses.concat(
           ffs_clause.conditions.map((condition) => get_query_clause(condition))
         );
@@ -360,13 +294,11 @@ export async function ffs_construct_query(
         types = types.indexOf(cond_query.type) != -1 ? [cond_query.type] : [];
       } else {
         // add another query clause
-        clauses_str.push(get_query_clause_str(cond_query));
         const clause = get_query_clause(cond_query);
         if (clause === false) throw new Error("unknown query clause");
         clauses.push(clause);
       }
     }
-    clauses_str = clauses_str.join(" and ");
 
     // construct query
     if (types.length === 3) {

--- a/js/ffs.ts
+++ b/js/ffs.ts
@@ -97,7 +97,9 @@ function dateValue(val: string): string {
 
 export async function ffs_construct_query(
   search: string,
-  comment: string | false | undefined
+  /** the comment to head the query with, `true` for the default one, or
+   * `false` to generate no comments at all */
+  comment: string | boolean | undefined
 ): Promise<string> {
   function quote_comment_str(s: string): string {
     // quote strings that are to be used within c-style comments

--- a/js/ffs/free.ts
+++ b/js/ffs/free.ts
@@ -73,7 +73,7 @@ export default async function ffs_free() {
   }
   // load preset translations
   async function loadPresetTranslations() {
-    let language = i18n.getLanguage();
+    let language: string = i18n.getLanguage();
     if (!language) return;
     try {
       let {default: data} = await import(

--- a/js/ffs/free.ts
+++ b/js/ffs/free.ts
@@ -88,8 +88,8 @@ export default async function ffs_free() {
       }
       data = data[language].presets.presets;
       // load translated names and terms into presets object
-      Object.entries(data).forEach(
-        ([presetName, translation]: [string, PresetTranslation]) => {
+      Object.entries(data as Record<string, PresetTranslation>).forEach(
+        ([presetName, translation]) => {
           const preset = presets[presetName];
           preset.translated = true;
           // save original preset name under alternative terms

--- a/js/ide.ts
+++ b/js/ide.ts
@@ -334,10 +334,10 @@ class IDE {
   init() {
     this.waiter.addInfo("ide starting up");
     $("#overpass-turbo-version").html(
-      `overpass-turbo <code>${GIT_VERSION}</code>` // eslint-disable-line no-undef
+      `overpass-turbo <code>${import.meta.env.VITE_GIT_VERSION}</code>`
     );
     $("#overpass-turbo-dependencies").html(
-      APP_DEPENDENCIES // eslint-disable-line no-undef
+      import.meta.env.VITE_APP_DEPENDENCIES
     );
     // (very raw) compatibility check <- TODO: put this into its own function
     if (

--- a/js/ide.ts
+++ b/js/ide.ts
@@ -1357,7 +1357,7 @@ class IDE {
     // - preparations -
     const q = this.getRawQuery(), // get original query
       lng = this.getQueryLang();
-    const autorepair = Autorepair(q, lng);
+    const autorepair = new Autorepair(q, lng);
     // - repairs -
     if (repair == "no visible data") {
       // repair missing recurse statements
@@ -2246,7 +2246,7 @@ class IDE {
 
     // OSM editors
     // first check for possible mistakes in query.
-    const validEditorQuery = Autorepair.detect.editors(
+    const validEditorQuery = Autorepair.isEditorCompatible(
       this.getRawQuery(),
       this.getQueryLang()
     );
@@ -2331,7 +2331,7 @@ class IDE {
           }
         }
         // first check for possible mistakes in query.
-        const valid = Autorepair.detect.editors(
+        const valid = Autorepair.isEditorCompatible(
           this.getRawQuery(),
           this.getQueryLang()
         );

--- a/js/ide.ts
+++ b/js/ide.ts
@@ -3,8 +3,8 @@ import CodeMirror from "codemirror";
 import {default as colorbrewer} from "colorbrewer";
 import colormap from "colormap";
 import html2canvas from "html2canvas";
-import "leaflet";
 import $ from "jquery";
+import * as L from "leaflet";
 // global ide object
 import debounce from "lodash/debounce";
 import togpx from "togpx";

--- a/js/ide.ts
+++ b/js/ide.ts
@@ -1809,7 +1809,8 @@ class IDE {
     query_umap = query_umap.replace(/\n\s*/g, "");
     // replace bbox with south west north east
     query_umap = query_umap.replace(
-      new RegExp(shortcuts().bbox, "g"),
+      // the bbox shortcut is expanded to a string, unlike the async ones
+      new RegExp(shortcuts().bbox as string, "g"),
       "{south},{west},{north},{east}"
     );
     $("#export-text_umap .format").html(i18n.t("export.format_text_umap"));

--- a/js/ide.ts
+++ b/js/ide.ts
@@ -943,9 +943,6 @@ class IDE {
       }
     });
 
-    // init overpass object
-    overpass.init();
-
     // event handlers for overpass object
     overpass.handlers["onProgress"] = function (msg, abortcallback) {
       ide.waiter.addInfo(msg, abortcallback);

--- a/js/jsmapcss/Condition.ts
+++ b/js/jsmapcss/Condition.ts
@@ -36,7 +36,7 @@ export class Condition {
       case "ne":
         return value != p[1];
       case "regex":
-        return value !== undefined && new RegExp(p[1], "i").test(value);
+        return value !== undefined && new RegExp(p[1], "i").test(String(value));
       case "true":
         return value == "true" || value == "yes" || value == "1";
       case "false":

--- a/js/jsmapcss/Condition.ts
+++ b/js/jsmapcss/Condition.ts
@@ -1,53 +1,63 @@
-// ----------------------------------------------------------------------
-// Condition base class
+import type {Tags} from "./Style";
 
-import styleparser from "./Style";
+/** The comparison a {@link Condition} applies to a tag. */
+export type ConditionType =
+  | "eq"
+  | "ne"
+  | "regex"
+  | "true"
+  | "false"
+  | "set"
+  | "unset"
+  | "<"
+  | "<="
+  | ">"
+  | ">=";
 
-styleparser.Condition = function () {};
-styleparser.Condition.prototype = {
-  type: "", // eq/ne/regex etc.
-  params: [], // what to test against
+/** A single `[…]` test of a MapCSS selector, such as `[highway=primary]`. */
+export class Condition {
+  /** The tag key to test, followed by the value to test it against. */
+  params: string[] = [];
 
-  init(_type, ..._params) {
-    // summary:		A condition to evaluate.
-    this.type = _type;
-    this.params = _params;
-    return this;
-  },
+  constructor(
+    public type: ConditionType,
+    ...params: string[]
+  ) {
+    this.params = params;
+  }
 
-  test(tags) {
-    // summary:		Run the condition against the supplied tags.
+  /** Runs the condition against the supplied tags. */
+  test(tags: Tags): boolean {
     const p = this.params;
+    const value = tags[p[0]];
     switch (this.type) {
       case "eq":
-        return tags[p[0]] == p[1];
+        return value == p[1];
       case "ne":
-        return tags[p[0]] != p[1];
+        return value != p[1];
       case "regex":
-        return (
-          tags[p[0]] !== undefined && new RegExp(p[1], "i").test(tags[p[0]])
-        );
+        return value !== undefined && new RegExp(p[1], "i").test(value);
       case "true":
-        return tags[p[0]] == "true" || tags[p[0]] == "yes" || tags[p[0]] == "1";
+        return value == "true" || value == "yes" || value == "1";
       case "false":
-        return tags[p[0]] == "false" || tags[p[0]] == "no" || tags[p[0]] == "0";
+        return value == "false" || value == "no" || value == "0";
       case "set":
-        return tags[p[0]] !== undefined && tags[p[0]] !== "";
+        return value !== undefined && value !== "";
       case "unset":
-        return tags[p[0]] === undefined || tags[p[0]] === "";
+        return value === undefined || value === "";
       case "<":
-        return Number(tags[p[0]]) < Number(p[1]);
+        return Number(value) < Number(p[1]);
       case "<=":
-        return Number(tags[p[0]]) <= Number(p[1]);
+        return Number(value) <= Number(p[1]);
       case ">":
-        return Number(tags[p[0]]) > Number(p[1]);
+        return Number(value) > Number(p[1]);
       case ">=":
-        return Number(tags[p[0]]) >= Number(p[1]);
+        return Number(value) >= Number(p[1]);
     }
     return false;
-  },
+  }
 
-  toString() {
+  toString(): string {
     return `[${this.type}: ${this.params}]`;
   }
-};
+}

--- a/js/jsmapcss/InstructionStyle.ts
+++ b/js/jsmapcss/InstructionStyle.ts
@@ -1,0 +1,21 @@
+import {Style, prototypeDefaults} from "./Style";
+
+/** The `set tag=value` and `exit` instructions of a MapCSS declaration. */
+export class InstructionStyle extends Style {
+  /** Tags to add to the feature before evaluating the remaining rules. */
+  declare set_tags: Record<string, string | boolean> | null;
+  /** Whether this declaration stops the feature being styled any further. */
+  declare breaker: boolean;
+
+  addSetTag(k: string, v: string | boolean): void {
+    this.edited = true;
+    if (!this.set_tags) this.set_tags = {};
+    this.set_tags[k] = v;
+  }
+}
+
+prototypeDefaults(InstructionStyle, {
+  styleType: "InstructionStyle",
+  set_tags: null,
+  breaker: false
+});

--- a/js/jsmapcss/InstructionStyle.ts
+++ b/js/jsmapcss/InstructionStyle.ts
@@ -1,11 +1,12 @@
-import {Style, prototypeDefaults} from "./Style";
+import {Style} from "./Style";
 
 /** The `set tag=value` and `exit` instructions of a MapCSS declaration. */
 export class InstructionStyle extends Style {
+  override styleType = "InstructionStyle";
   /** Tags to add to the feature before evaluating the remaining rules. */
-  declare set_tags: Record<string, string | boolean> | null;
+  set_tags: Record<string, string | boolean> | null = null;
   /** Whether this declaration stops the feature being styled any further. */
-  declare breaker: boolean;
+  breaker = false;
 
   addSetTag(k: string, v: string | boolean): void {
     this.edited = true;
@@ -13,9 +14,3 @@ export class InstructionStyle extends Style {
     this.set_tags[k] = v;
   }
 }
-
-prototypeDefaults(InstructionStyle, {
-  styleType: "InstructionStyle",
-  set_tags: null,
-  breaker: false
-});

--- a/js/jsmapcss/PointStyle.ts
+++ b/js/jsmapcss/PointStyle.ts
@@ -1,37 +1,9 @@
-import {Style, prototypeDefaults} from "./Style";
+import {Style} from "./Style";
 
 /** How a feature is drawn as a point: an icon, or an overpass turbo symbol. */
 export class PointStyle extends Style {
-  declare icon_image: string | null;
-  declare icon_width: number;
-  declare icon_height: number;
-  declare icon_opacity: number;
-  declare rotation: number;
-
-  /*
-   * overpass turbo's own MapCSS extension: the symbol-* properties.
-   * TODO: implement symbol-shape = marker|square?|shield?|...
-   */
-  declare symbol_shape: string;
-  declare symbol_size: number;
-  declare symbol_stroke_width: number;
-  declare symbol_stroke_color: string | null;
-  declare symbol_stroke_opacity: number;
-  declare symbol_fill_color: string | null;
-  declare symbol_fill_opacity: number;
-
-  override drawn(): boolean {
-    return this.icon_image !== null;
-  }
-
-  maxwidth(): number {
-    return this.evals.icon_width ? 0 : this.icon_width;
-  }
-}
-
-prototypeDefaults(PointStyle, {
-  styleType: "PointStyle",
-  properties: [
+  override styleType = "PointStyle";
+  override properties = [
     "icon_image",
     "icon_width",
     "icon_height",
@@ -44,16 +16,31 @@ prototypeDefaults(PointStyle, {
     "symbol_stroke_opacity",
     "symbol_fill_color",
     "symbol_fill_opacity"
-  ],
-  icon_image: null,
-  icon_width: 0,
-  icon_height: NaN,
-  rotation: NaN,
-  symbol_shape: "",
-  symbol_size: NaN,
-  symbol_stroke_width: NaN,
-  symbol_stroke_color: null,
-  symbol_stroke_opacity: NaN,
-  symbol_fill_color: null,
-  symbol_fill_opacity: NaN
-});
+  ];
+
+  icon_image: string | null = null;
+  icon_width = 0;
+  icon_height = NaN;
+  icon_opacity = NaN;
+  rotation = NaN;
+
+  /*
+   * overpass turbo's own MapCSS extension: the symbol-* properties.
+   * TODO: implement symbol-shape = marker|square?|shield?|...
+   */
+  symbol_shape = "";
+  symbol_size = NaN;
+  symbol_stroke_width = NaN;
+  symbol_stroke_color: string | null = null;
+  symbol_stroke_opacity = NaN;
+  symbol_fill_color: string | null = null;
+  symbol_fill_opacity = NaN;
+
+  override drawn(): boolean {
+    return this.icon_image !== null;
+  }
+
+  maxwidth(): number {
+    return this.evals.icon_width ? 0 : this.icon_width;
+  }
+}

--- a/js/jsmapcss/PointStyle.ts
+++ b/js/jsmapcss/PointStyle.ts
@@ -1,0 +1,59 @@
+import {Style, prototypeDefaults} from "./Style";
+
+/** How a feature is drawn as a point: an icon, or an overpass turbo symbol. */
+export class PointStyle extends Style {
+  declare icon_image: string | null;
+  declare icon_width: number;
+  declare icon_height: number;
+  declare icon_opacity: number;
+  declare rotation: number;
+
+  /*
+   * overpass turbo's own MapCSS extension: the symbol-* properties.
+   * TODO: implement symbol-shape = marker|square?|shield?|...
+   */
+  declare symbol_shape: string;
+  declare symbol_size: number;
+  declare symbol_stroke_width: number;
+  declare symbol_stroke_color: string | null;
+  declare symbol_stroke_opacity: number;
+  declare symbol_fill_color: string | null;
+  declare symbol_fill_opacity: number;
+
+  override drawn(): boolean {
+    return this.icon_image !== null;
+  }
+
+  maxwidth(): number {
+    return this.evals.icon_width ? 0 : this.icon_width;
+  }
+}
+
+prototypeDefaults(PointStyle, {
+  styleType: "PointStyle",
+  properties: [
+    "icon_image",
+    "icon_width",
+    "icon_height",
+    "icon_opacity",
+    "rotation",
+    "symbol_shape",
+    "symbol_size",
+    "symbol_stroke_width",
+    "symbol_stroke_color",
+    "symbol_stroke_opacity",
+    "symbol_fill_color",
+    "symbol_fill_opacity"
+  ],
+  icon_image: null,
+  icon_width: 0,
+  icon_height: NaN,
+  rotation: NaN,
+  symbol_shape: "",
+  symbol_size: NaN,
+  symbol_stroke_width: NaN,
+  symbol_stroke_color: null,
+  symbol_stroke_opacity: NaN,
+  symbol_fill_color: null,
+  symbol_fill_opacity: NaN
+});

--- a/js/jsmapcss/Rule.ts
+++ b/js/jsmapcss/Rule.ts
@@ -1,57 +1,55 @@
-// ----------------------------------------------------------------------
-// Rule class
+import type {Condition} from "./Condition";
+import type {Tags} from "./Style";
 
-import styleparser from "./Style";
+/** The map feature a rule is evaluated against. */
+export interface Entity {
+  /** Whether the feature is of the given type: `way`, `node`, `relation`, … */
+  isSubject(subject: string): boolean;
+  /** The features this one belongs to, used to walk a descendant selector. */
+  getParentObjects(): Entity[];
+  tags?: Tags;
+}
 
-styleparser.Rule = function () {};
-styleparser.Rule.prototype = {
-  conditions: [], // the Conditions to be evaluated for the Rule to be fulfilled
-  isAnd: true, // do all Conditions need to be true for the Rule to be fulfilled? (Always =true for MapCSS)
-  minZoom: 0, // minimum zoom level at which the Rule is fulfilled
-  maxZoom: 255, // maximum zoom level at which the Rule is fulfilled
-  subject: "", // entity type to which the Rule applies: 'way', 'node', 'relation', 'area' (closed way), 'line' (unclosed way), or '*' (everything)
+/**
+ * A MapCSS selector: a list of conditions, the entity type they apply to, and
+ * the zoom levels at which they hold. `way[waterway=river][boat=yes]` is one
+ * Rule. Rules and a declaration together form a {@link StyleChooser}.
+ */
+export class Rule {
+  /** The conditions that must hold for the rule to be fulfilled. */
+  conditions: Condition[] = [];
+  /** Minimum zoom level at which the rule is fulfilled. */
+  minZoom = 0;
+  /** Maximum zoom level at which the rule is fulfilled. */
+  maxZoom = 255;
+  /**
+   * Entity type the rule applies to: `way`, `node`, `relation`, `area` (a
+   * closed way), `line` (an unclosed way), or `*` for everything.
+   */
+  subject = "";
 
-  addSubject(_subject) {
-    // summary:		A MapCSS selector. Contains a list of Conditions; the entity type to which the selector applies;
-    //				and the zoom levels at which it is true. way[waterway=river][boat=yes] would be parsed into one Rule.
-    //				The selectors and declaration together form a StyleChooser.
-    this.subject = _subject;
+  addSubject(subject: string): void {
+    this.subject = subject;
     this.conditions = [];
-  },
+  }
 
-  addCondition(_condition) {
-    // summary:		Add a condition to this rule.
-    this.conditions.push(_condition);
-  },
+  addCondition(condition: Condition): void {
+    this.conditions.push(condition);
+  }
 
-  test(entity, tags, zoom) {
-    // summary: Evaluate the Rule on the given entity, tags and zoom level.
-    // returns: true if the Rule passes, false if the conditions aren't fulfilled.
+  /** Whether the rule holds for the given entity, tags and zoom level. */
+  test(entity: Entity, tags: Tags, zoom: number): boolean {
     if (this.subject !== "" && !entity.isSubject(this.subject)) {
       return false;
     }
     if (zoom < this.minZoom || zoom > this.maxZoom) {
       return false;
     }
+    // MapCSS only ever ands conditions together.
+    return this.conditions.every((condition) => condition.test(tags));
+  }
 
-    let v = true;
-    let i = 0;
-    const isAnd = this.isAnd;
-    this.conditions.forEach((condition) => {
-      const r = condition.test(tags);
-      if (i === 0) {
-        v = r;
-      } else if (isAnd) {
-        v = v && r;
-      } else {
-        v = v || r;
-      }
-      i++;
-    });
-    return v;
-  },
-
-  toString() {
+  toString(): string {
     return `${this.subject} z${this.minZoom}-${this.maxZoom}: ${this.conditions}`;
   }
-};
+}

--- a/js/jsmapcss/RuleChain.ts
+++ b/js/jsmapcss/RuleChain.ts
@@ -71,6 +71,6 @@ export class RuleChain {
 
     return entity
       .getParentObjects()
-      .some((parent) => this.test(pos - 1, parent, parent.tags, zoom));
+      .some((parent) => this.test(pos - 1, parent, parent.tags ?? {}, zoom));
   }
 }

--- a/js/jsmapcss/RuleChain.ts
+++ b/js/jsmapcss/RuleChain.ts
@@ -1,80 +1,76 @@
-// ----------------------------------------------------------------------
-// RuleChain base class
-// In contrast to Halcyon, note that length() is a function, not a getter property
+import type {Condition} from "./Condition";
+import {type Entity, Rule} from "./Rule";
+import type {Tags} from "./Style";
 
-/**	A descendant list of MapCSS selectors (Rules).
+/**
+ * A descendant list of MapCSS selectors, for example
+ *
+ * ```text
+ * relation[type=route] way[highway=primary]
+ * ^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^
+ * first Rule           second Rule
+ * ```
+ *
+ * which together form one RuleChain.
+ *
+ * In contrast to Halcyon, note that length() is a function, not a getter
+ * property.
+ */
+export class RuleChain {
+  rules: Rule[] = [];
+  /** Subpart name, as in `way[highway=primary]::centreline`. */
+  subpart = "default";
 
-  For example,
-  relation[type=route] way[highway=primary]
-  ^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^
-  first Rule           second Rule
-  |------------|---------|
-  |
-  one RuleChain
+  addRule(subject?: string): void {
+    const rule = new Rule();
+    rule.addSubject(subject ?? "");
+    this.rules.push(rule);
+  }
 
-*/
+  addConditionToLast(condition: Condition): void {
+    this.rules[this.rules.length - 1].addCondition(condition);
+  }
 
-import styleparser from "./Style";
+  addZoomToLast(minZoom: number, maxZoom: number): void {
+    const last = this.rules[this.rules.length - 1];
+    last.minZoom = minZoom;
+    last.maxZoom = maxZoom;
+  }
 
-styleparser.RuleChain = function () {
-  this.rules = []; // list of Rules
-  this.subpart = "default"; // subpart name, as in way[highway=primary]::centreline
-};
-styleparser.RuleChain.prototype = {
-  // Functions to define the RuleChain
-  addRule(_subject) {
-    this.rules.push(new styleparser.Rule());
-    this.rules[this.rules.length - 1].addSubject(_subject);
-  },
-
-  addConditionToLast(_condition) {
-    this.rules[this.rules.length - 1].addCondition(_condition);
-  },
-
-  addZoomToLast(z1, z2) {
-    this.rules[this.rules.length - 1].minZoom = z1;
-    this.rules[this.rules.length - 1].maxZoom = z2;
-  },
-
-  length() {
+  length(): number {
     return this.rules.length;
-  },
+  }
 
-  setSubpart(subpart) {
+  setSubpart(subpart: string): void {
     this.subpart = subpart || "default";
-  },
+  }
 
-  // Test a ruleChain
-  // - run a set of tests in the chain
-  //		works backwards from at position "pos" in array, or -1  for the last
-  //		separate tags object is required in case they've been dynamically retagged
-  // - if they fail, return false
-  // - if they succeed, and it's the last in the chain, return happily
-  // - if they succeed, and there's more in the chain, rerun this for each parent until success
-
-  test(pos, entity, tags, zoom) {
-    // summary:		Test a rule chain by running all the tests in reverse order.
+  /**
+   * Tests the chain by running its rules in reverse order, starting at `pos`
+   * or, for -1, at the end of the chain. A separate tags object is required in
+   * case the feature has been dynamically retagged.
+   *
+   * Once a rule passes, the rule before it is tried against each of the
+   * feature's parents in turn, so that a descendant selector matches if any
+   * ancestry satisfies it.
+   */
+  test(pos: number, entity: Entity, tags: Tags, zoom: number): boolean {
     if (this.rules.length === 0) {
-      return true;
-    } // orig: { return false; } // todo: wildcard selector "*" semms broken...
+      return true; // orig: { return false; } // todo: wildcard selector "*" semms broken...
+    }
     if (pos == -1) {
       pos = this.rules.length - 1;
     }
 
-    const r = this.rules[pos];
-    if (!r.test(entity, tags, zoom)) {
+    if (!this.rules[pos].test(entity, tags, zoom)) {
       return false;
     }
     if (pos === 0) {
       return true;
     }
 
-    const o = entity.getParentObjects(); //TODO//entity.entity.parentObjects();
-    for (const p of o) {
-      if (this.test(pos - 1, p, p.tags, zoom)) {
-        return true;
-      }
-    }
-    return false;
+    return entity
+      .getParentObjects()
+      .some((parent) => this.test(pos - 1, parent, parent.tags, zoom));
   }
-};
+}

--- a/js/jsmapcss/RuleSet.ts
+++ b/js/jsmapcss/RuleSet.ts
@@ -2,509 +2,428 @@
 // needs to cope with nested CSS files
 // doesn't do untagged nodes optimisation
 
-import styleparser from "./Style";
+import {Condition, type ConditionType} from "./Condition";
+import {InstructionStyle} from "./InstructionStyle";
+import {PointStyle} from "./PointStyle";
+import type {Entity} from "./Rule";
+import {ShapeStyle} from "./ShapeStyle";
+import {ShieldStyle} from "./ShieldStyle";
+import type {Style, Tags} from "./Style";
+import {StyleChooser} from "./StyleChooser";
+import {StyleList} from "./StyleList";
+import {TextStyle} from "./TextStyle";
 
-styleparser.RuleSet = function () {};
+// Regular expression tests and other constants
 
-styleparser.RuleSet.prototype = {
-  choosers: [], // list of StyleChoosers
+const WHITESPACE = /^\s+/;
+const COMMENT = /\/\*.+?\*\/\s*/;
+const CLASS = /^([.:]\w+)\s*/;
+const NOT_CLASS = /^!([.:]\w+)\s*/;
+const ZOOM = /^\|\s*z([\d-]+)\s*/i;
+const GROUP = /^,\s*/i;
+const CONDITION = /^\[(.+?)\]\s*/;
+const OBJECT = /^(way|node|relation|line|area|canvas|\*)\s*/;
+const DECLARATION = /^\{(.+?)\}\s*/;
+const SUBPART = /^::(\w+)\s*/;
+const UNKNOWN = /^(\S+)\s*/;
 
-  getStyles(entity, tags, zoom) {
-    // summary:		Find the styles for a given entity.
-    const sl = new styleparser.StyleList();
-    for (const i in this.choosers) {
-      this.choosers[i].updateStyles(entity, tags, sl, zoom);
+const ZOOM_MINMAX = /^(\d+)-(\d+)$/;
+const ZOOM_MIN = /^(\d+)-$/;
+const ZOOM_MAX = /^-(\d+)$/;
+const ZOOM_SINGLE = /^(\d+)$/;
+
+/** Condition patterns, in the order they must be tried. */
+const CONDITIONS: [ConditionType, RegExp][] = [
+  ["true", /^\s*([:@\w]+)\s*=\s*yes\s*$/i],
+  ["false", /^\s*([:@\w]+)\s*=\s*no\s*$/i],
+  ["set", /^\s*([:@\w]+)\s*$/],
+  ["unset", /^\s*!([:@\w]+)\s*$/],
+  ["ne", /^\s*([:@\w]+)\s*!=\s*(.+)\s*$/],
+  [">", /^\s*([:@\w]+)\s*>\s*(.+)\s*$/],
+  [">=", /^\s*([:@\w]+)\s*>=\s*(.+)\s*$/],
+  ["<", /^\s*([:@\w]+)\s*<\s*(.+)\s*$/],
+  ["<=", /^\s*([:@\w]+)\s*<=\s*(.+)\s*$/],
+  ["regex", /^\s*([:@\w]+)\s*=~\/\s*(.+)\/\s*$/],
+  ["eq", /^\s*([:@\w]+)\s*=\s*(.+)\s*$/]
+];
+
+// TODO: match only two matching quotes
+const ASSIGNMENT_EVAL = /^\s*(\S+)\s*:\s*eval\s*\(\s*['"](.+?)['"]\s*\)\s*$/i;
+const ASSIGNMENT = /^\s*(\S+)\s*:\s*(.+?)\s*$/;
+const SET_TAG_EVAL = /^\s*set\s+(\S+)\s*=\s*eval\s*\(\s*'(.+?)'\s*\)\s*$/i;
+const SET_TAG = /^\s*set\s+(\S+)\s*=\s*(.+?)\s*$/i;
+const SET_TAG_TRUE = /^\s*set\s+(\S+)\s*$/i;
+const EXIT = /^\s*exit\s*$/i;
+
+const DASH = /-/g;
+const HEX = /^#([0-9a-f]+)$/i;
+
+/** The kind of token last consumed by {@link RuleSet.parseCSS}. */
+const enum Token {
+  None,
+  Zoom,
+  Group,
+  Condition,
+  Object,
+  Declaration,
+  Subpart
+}
+
+// TODO: hardcoded
+const MAX_SCALE = 999;
+const MIN_SCALE = -999;
+
+/** A parsed MapCSS stylesheet: a list of {@link StyleChooser}s. */
+export class RuleSet {
+  choosers: StyleChooser[] = [];
+  /** Invoked once a stylesheet has been parsed. */
+  callback?: () => void;
+
+  /** Finds the styles for a given entity. */
+  getStyles(entity: Entity, tags: Tags, zoom: number): StyleList {
+    const sl = new StyleList();
+    for (const chooser of this.choosers) {
+      chooser.updateStyles(entity, tags, sl, zoom);
     }
-    return sl; // styleparser.StyleList
-  },
+    return sl;
+  }
 
-  parseCSS(css) {
-    // summary:		Parse a CSS document into a set of StyleChoosers.
-    let previous = 0; // what was the previous CSS word?
-    let sc = new styleparser.StyleChooser(); // currently being assembled
+  /** Parses a CSS document into a set of StyleChoosers. */
+  parseCSS(css: string): void {
+    let previous = Token.None; // what was the previous CSS word?
+    let sc = new StyleChooser(); // currently being assembled
     this.choosers = [];
     css = css.replace(/[\r\n]/g, ""); // strip linebreaks because JavaScript doesn't have the /s modifier
 
-    let o = {};
+    /** Starts a new StyleChooser once the previous declaration is complete. */
+    const saveIfDeclared = () => {
+      if (previous == Token.Declaration) {
+        this.choosers.push(sc);
+        sc = new StyleChooser();
+      }
+    };
+
+    let o: RegExpExecArray | null;
     while (css.length > 0) {
       // CSS comment
-      if ((o = this.COMMENT.exec(css))) {
-        css = css.replace(this.COMMENT, "");
+      if ((o = COMMENT.exec(css))) {
+        css = css.replace(COMMENT, "");
 
         // Whitespace (probably only at beginning of file)
-      } else if ((o = this.WHITESPACE.exec(css))) {
-        css = css.replace(this.WHITESPACE, "");
+      } else if ((o = WHITESPACE.exec(css))) {
+        css = css.replace(WHITESPACE, "");
 
         // Class - .motorway, .builtup, :hover
-      } else if ((o = this.CLASS.exec(css))) {
-        if (previous == this.oDECLARATION) {
-          this.saveChooser(sc);
-          sc = new styleparser.StyleChooser();
-        }
-
-        css = css.replace(this.CLASS, "");
-        sc.currentChain().addConditionToLast(
-          new styleparser.Condition().init("set", o[1])
-        );
-        previous = this.oCONDITION;
+      } else if ((o = CLASS.exec(css))) {
+        saveIfDeclared();
+        css = css.replace(CLASS, "");
+        sc.currentChain().addConditionToLast(new Condition("set", o[1]));
+        previous = Token.Condition;
 
         // Not class - !.motorway, !.builtup, !:hover
-      } else if ((o = this.NOT_CLASS.exec(css))) {
-        if (previous == this.oDECLARATION) {
-          this.saveChooser(sc);
-          sc = new styleparser.StyleChooser();
-        }
-
-        css = css.replace(this.NOT_CLASS, "");
-        sc.currentChain().addConditionToLast(
-          new styleparser.Condition().init("unset", o[1])
-        );
-        previous = this.oCONDITION;
+      } else if ((o = NOT_CLASS.exec(css))) {
+        saveIfDeclared();
+        css = css.replace(NOT_CLASS, "");
+        sc.currentChain().addConditionToLast(new Condition("unset", o[1]));
+        previous = Token.Condition;
 
         // Zoom
-      } else if ((o = this.ZOOM.exec(css))) {
-        if (previous != this.oOBJECT && previous != this.oCONDITION) {
+      } else if ((o = ZOOM.exec(css))) {
+        if (previous != Token.Object && previous != Token.Condition) {
           sc.currentChain().addRule();
         }
-
-        css = css.replace(this.ZOOM, "");
-        const z = this.parseZoom(o[1]);
-        sc.currentChain().addZoomToLast(z[0], z[1]);
+        css = css.replace(ZOOM, "");
+        const [minZoom, maxZoom] = parseZoom(o[1]);
+        sc.currentChain().addZoomToLast(minZoom, maxZoom);
         sc.zoomSpecific = true;
-        previous = this.oZOOM;
+        previous = Token.Zoom;
 
         // Grouping - just a comma
-      } else if ((o = this.GROUP.exec(css))) {
-        css = css.replace(this.GROUP, "");
+      } else if ((o = GROUP.exec(css))) {
+        css = css.replace(GROUP, "");
         sc.newRuleChain();
-        previous = this.oGROUP;
+        previous = Token.Group;
 
         // Condition - [highway=primary]
-      } else if ((o = this.CONDITION.exec(css))) {
-        if (previous == this.oDECLARATION) {
-          this.saveChooser(sc);
-          sc = new styleparser.StyleChooser();
-        }
+      } else if ((o = CONDITION.exec(css))) {
+        saveIfDeclared();
         if (
-          previous != this.oOBJECT &&
-          previous != this.oZOOM &&
-          previous != this.oCONDITION
+          previous != Token.Object &&
+          previous != Token.Zoom &&
+          previous != Token.Condition
         ) {
           sc.currentChain().addRule();
         }
-        css = css.replace(this.CONDITION, "");
-        sc.currentChain().addConditionToLast(this.parseCondition(o[1]));
-        previous = this.oCONDITION;
+        css = css.replace(CONDITION, "");
+        const condition = parseCondition(o[1]);
+        if (condition) sc.currentChain().addConditionToLast(condition);
+        previous = Token.Condition;
 
         // Object - way, node, relation
-      } else if ((o = this.OBJECT.exec(css))) {
+      } else if ((o = OBJECT.exec(css))) {
         // TODO: raise error if object is none of node|way|relation|line|area|canvas|* ?
-        if (previous == this.oDECLARATION) {
-          this.saveChooser(sc);
-          sc = new styleparser.StyleChooser();
-        }
-
-        css = css.replace(this.OBJECT, "");
+        saveIfDeclared();
+        css = css.replace(OBJECT, "");
         sc.currentChain().addRule(o[1]);
-        previous = this.oOBJECT;
+        previous = Token.Object;
 
         // Subpart - ::centreline
-      } else if ((o = this.SUBPART.exec(css))) {
-        if (previous == this.oDECLARATION) {
-          this.saveChooser(sc);
-          sc = new styleparser.StyleChooser();
-        }
-        css = css.replace(this.SUBPART, "");
+      } else if ((o = SUBPART.exec(css))) {
+        saveIfDeclared();
+        css = css.replace(SUBPART, "");
         sc.currentChain().setSubpart(o[1]);
-        previous = this.oSUBPART;
+        previous = Token.Subpart;
 
         // Declaration - {...}
-      } else if ((o = this.DECLARATION.exec(css))) {
-        css = css.replace(this.DECLARATION, "");
-        sc.addStyles(this.parseDeclaration(o[1]));
-        previous = this.oDECLARATION;
+      } else if ((o = DECLARATION.exec(css))) {
+        css = css.replace(DECLARATION, "");
+        sc.addStyles(parseDeclaration(o[1]));
+        previous = Token.Declaration;
 
         // Unknown pattern
-      } else if ((o = this.UNKNOWN.exec(css))) {
-        css = css.replace(this.UNKNOWN, "");
+      } else if ((o = UNKNOWN.exec(css))) {
+        css = css.replace(UNKNOWN, "");
         // TODO: own error class
         throw new Error(
           `Error while parsing MapCSS at "${o[1]}${
             css.length > 38 ? `${css.substr(0, 36)}...` : css
           }"`
         );
-        // console.log("unknown: "+o[1]);
       } else {
-        // console.log("choked on "+css);
         throw new Error(`MapCSS parsing choked on ${css}`);
       }
     }
-    if (previous == this.oDECLARATION) {
-      this.saveChooser(sc);
-      sc = new styleparser.StyleChooser();
-    }
-    if (this.callback) {
-      this.callback();
-    }
-  },
+    saveIfDeclared();
+    this.callback?.();
+  }
 
-  saveChooser(sc) {
-    this.choosers.push(sc);
-  },
-
-  parseDeclaration(s) {
-    const styles = [];
-    const t = {};
-    let o = {};
-    let k, v;
-
-    // Create styles
-    const ss = new styleparser.ShapeStyle();
-    const ps = new styleparser.PointStyle();
-    const ts = new styleparser.TextStyle();
-    const hs = new styleparser.ShieldStyle();
-    const xs = new styleparser.InstructionStyle();
-
-    const r = s.split(";");
-    const isEval = {};
-    for (const i in r) {
-      const a = r[i];
-      if ((o = this.ASSIGNMENT_EVAL.exec(a))) {
-        k = o[1].replace(this.DASH, "_");
-        t[k] = o[2];
-        isEval[k] = true;
-      } else if ((o = this.ASSIGNMENT.exec(a))) {
-        k = o[1].replace(this.DASH, "_");
-        t[k] = o[2];
-      } else if ((o = this.SET_TAG_EVAL.exec(a))) {
-      } else if ((o = this.SET_TAG.exec(a))) {
-        // xs.addSetTag(o[1],this.saveEval(o[2]));
-        xs.addSetTag(o[1], o[2]);
-      } else if ((o = this.SET_TAG_TRUE.exec(a))) {
-        xs.addSetTag(o[1], true);
-      } else if ((o = this.EXIT.exec(a))) {
-        xs.setPropertyFromString("breaker", true);
-      }
-    }
-
-    /*// Find sublayer
-        // TODO: Why the renaming z_index -> sublayer?
-        //       This hardcoded variable isn't used anywhere.
-        //       Looks like this was replaced by the "subparts"...
-        var sub=5;
-        if (t['z_index']) { sub=Number(t['z_index']); delete t['z_index']; }
-        ss.sublayer=ps.sublayer=ts.sublayer=hs.sublayer=sub;
-        xs.sublayer=10;*/
-
-    /*// Find "interactive" property - it's true unless explicitly set false
-        var inter=true;
-        if (t['interactive']) { inter=t['interactive'].match(this.FALSE) ? false : true; delete t['interactive']; }
-        ss.interactive=ps.interactive=ts.interactive=hs.interactive=xs.interactive=inter;*/
-
-    // Assign each property to the appropriate style
-    for (const a in t) {
-      // Parse properties
-      v = t[a];
-
-      // Set in styles
-      if (ss.has(a)) {
-        ss.setPropertyFromString(a, v, isEval[a]);
-      } else if (ps.has(a)) {
-        ps.setPropertyFromString(a, v, isEval[a]);
-      } else if (ts.has(a)) {
-        ts.setPropertyFromString(a, v, isEval[a]);
-      } else if (hs.has(a)) {
-        hs.setPropertyFromString(a, v, isEval[a]);
-      } else {
-        // console.log(a+" not found");
-      }
-    }
-
-    // Add each style to list
-    if (ss.edited) {
-      styles.push(ss);
-    }
-    if (ps.edited) {
-      styles.push(ps);
-    }
-    if (ts.edited) {
-      styles.push(ts);
-    }
-    if (hs.edited) {
-      styles.push(hs);
-    }
-    if (xs.edited) {
-      styles.push(xs);
-    }
-    return styles;
-  },
-
-  parseZoom(s) {
-    let o = {};
-    const maxscale = 999; // TODO: hardcoded
-    const minscale = -999; // TODO: hardcoded
-    if ((o = this.ZOOM_MINMAX.exec(s))) {
-      return [o[1], o[2]];
-    } else if ((o = this.ZOOM_MIN.exec(s))) {
-      return [o[1], maxscale];
-    } else if ((o = this.ZOOM_MAX.exec(s))) {
-      return [minscale, o[1]];
-    } else if ((o = this.ZOOM_SINGLE.exec(s))) {
-      return [o[1], o[1]];
-    }
-    return null;
-  },
-
-  parseCondition(s) {
-    let o = {};
-    if ((o = this.CONDITION_TRUE.exec(s))) {
-      return new styleparser.Condition().init("true", o[1]);
-    } else if ((o = this.CONDITION_FALSE.exec(s))) {
-      return new styleparser.Condition().init("false", o[1]);
-    } else if ((o = this.CONDITION_SET.exec(s))) {
-      return new styleparser.Condition().init("set", o[1]);
-    } else if ((o = this.CONDITION_UNSET.exec(s))) {
-      return new styleparser.Condition().init("unset", o[1]);
-    } else if ((o = this.CONDITION_NE.exec(s))) {
-      return new styleparser.Condition().init("ne", o[1], o[2]);
-    } else if ((o = this.CONDITION_GT.exec(s))) {
-      return new styleparser.Condition().init(">", o[1], o[2]);
-    } else if ((o = this.CONDITION_GE.exec(s))) {
-      return new styleparser.Condition().init(">=", o[1], o[2]);
-    } else if ((o = this.CONDITION_LT.exec(s))) {
-      return new styleparser.Condition().init("<", o[1], o[2]);
-    } else if ((o = this.CONDITION_LE.exec(s))) {
-      return new styleparser.Condition().init("<=", o[1], o[2]);
-    } else if ((o = this.CONDITION_REGEX.exec(s))) {
-      return new styleparser.Condition().init("regex", o[1], o[2]);
-    } else if ((o = this.CONDITION_EQ.exec(s))) {
-      return new styleparser.Condition().init("eq", o[1], o[2]);
-    }
-    return null;
-  },
-
-  parseCSSColor(colorStr) {
+  /** Converts a CSS colour name or hex triplet to a numeric colour. */
+  parseCSSColor(colorStr: string): number {
     // todo: this should be done at user (=style consumer) side (if necessary).
     // -> move to a more appropriate location
     colorStr = colorStr.toLowerCase();
-    if (this.CSSCOLORS[colorStr]) {
-      return this.CSSCOLORS[colorStr];
-    } else {
-      const match = this.HEX.exec(colorStr);
-      if (match) {
-        if (match[1].length == 3) {
-          // repeat digits. #abc => 0xaabbcc
-          return Number(
-            `0x${match[1].charAt(0)}${match[1].charAt(0)}${match[1].charAt(
-              1
-            )}${match[1].charAt(1)}${match[1].charAt(2)}${match[1].charAt(2)}`
-          );
-        } else if (match[1].length == 6) {
-          return Number(`0x${match[1]}`);
-        } else {
-          return Number("0x000000"); //as good as any
-        }
+    if (CSSCOLORS[colorStr]) {
+      return CSSCOLORS[colorStr];
+    }
+    const match = HEX.exec(colorStr);
+    if (match) {
+      if (match[1].length == 3) {
+        // repeat digits. #abc => 0xaabbcc
+        const [r, g, b] = match[1];
+        return Number(`0x${r}${r}${g}${g}${b}${b}`);
+      } else if (match[1].length == 6) {
+        return Number(`0x${match[1]}`);
       }
+      return 0x000000; // as good as any
     }
     return 0;
-  },
-
-  // Regular expression tests and other constants
-
-  WHITESPACE: /^\s+/,
-  COMMENT: /\/\*.+?\*\/\s*/,
-  CLASS: /^([.:]\w+)\s*/,
-  NOT_CLASS: /^!([.:]\w+)\s*/,
-  ZOOM: /^\|\s*z([\d-]+)\s*/i,
-  GROUP: /^,\s*/i,
-  CONDITION: /^\[(.+?)\]\s*/,
-  OBJECT: /^(way|node|relation|line|area|canvas|\*)\s*/,
-  DECLARATION: /^\{(.+?)\}\s*/,
-  SUBPART: /^::(\w+)\s*/,
-  UNKNOWN: /^(\S+)\s*/,
-
-  ZOOM_MINMAX: /^(\d+)-(\d+)$/,
-  ZOOM_MIN: /^(\d+)-$/,
-  ZOOM_MAX: /^-(\d+)$/,
-  ZOOM_SINGLE: /^(\d+)$/,
-
-  CONDITION_TRUE: /^\s*([:@\w]+)\s*=\s*yes\s*$/i,
-  CONDITION_FALSE: /^\s*([:@\w]+)\s*=\s*no\s*$/i,
-  CONDITION_SET: /^\s*([:@\w]+)\s*$/,
-  CONDITION_UNSET: /^\s*!([:@\w]+)\s*$/,
-  CONDITION_EQ: /^\s*([:@\w]+)\s*=\s*(.+)\s*$/,
-  CONDITION_NE: /^\s*([:@\w]+)\s*!=\s*(.+)\s*$/,
-  CONDITION_GT: /^\s*([:@\w]+)\s*>\s*(.+)\s*$/,
-  CONDITION_GE: /^\s*([:@\w]+)\s*>=\s*(.+)\s*$/,
-  CONDITION_LT: /^\s*([:@\w]+)\s*<\s*(.+)\s*$/,
-  CONDITION_LE: /^\s*([:@\w]+)\s*<=\s*(.+)\s*$/,
-  CONDITION_REGEX: /^\s*([:@\w]+)\s*=~\/\s*(.+)\/\s*$/,
-
-  ASSIGNMENT_EVAL: /^\s*(\S+)\s*:\s*eval\s*\(\s*['"](.+?)['"]\s*\)\s*$/i, // TODO: match only two matching quotes
-  ASSIGNMENT: /^\s*(\S+)\s*:\s*(.+?)\s*$/,
-  SET_TAG_EVAL: /^\s*set\s+(\S+)\s*=\s*eval\s*\(\s*'(.+?)'\s*\)\s*$/i,
-  SET_TAG: /^\s*set\s+(\S+)\s*=\s*(.+?)\s*$/i,
-  SET_TAG_TRUE: /^\s*set\s+(\S+)\s*$/i,
-  EXIT: /^\s*exit\s*$/i,
-
-  oZOOM: 2,
-  oGROUP: 3,
-  oCONDITION: 4,
-  oOBJECT: 5,
-  oDECLARATION: 6,
-  oSUBPART: 7,
-
-  DASH: /-/g,
-  COLOR: /color$/,
-  BOLD: /^bold$/i,
-  ITALIC: /^italic|oblique$/i,
-  UNDERLINE: /^underline$/i,
-  CAPS: /^uppercase$/i,
-  CENTER: /^center$/i,
-  FALSE: /^(no|false|0)$/i,
-
-  HEX: /^#([0-9a-f]+)$/i,
-
-  CSSCOLORS: {
-    aliceblue: 0xf0f8ff,
-    antiquewhite: 0xfaebd7,
-    aqua: 0x00ffff,
-    aquamarine: 0x7fffd4,
-    azure: 0xf0ffff,
-    beige: 0xf5f5dc,
-    bisque: 0xffe4c4,
-    black: 0x000000,
-    blanchedalmond: 0xffebcd,
-    blue: 0x0000ff,
-    blueviolet: 0x8a2be2,
-    brown: 0xa52a2a,
-    burlywood: 0xdeb887,
-    cadetblue: 0x5f9ea0,
-    chartreuse: 0x7fff00,
-    chocolate: 0xd2691e,
-    coral: 0xff7f50,
-    cornflowerblue: 0x6495ed,
-    cornsilk: 0xfff8dc,
-    crimson: 0xdc143c,
-    cyan: 0x00ffff,
-    darkblue: 0x00008b,
-    darkcyan: 0x008b8b,
-    darkgoldenrod: 0xb8860b,
-    darkgray: 0xa9a9a9,
-    darkgreen: 0x006400,
-    darkkhaki: 0xbdb76b,
-    darkmagenta: 0x8b008b,
-    darkolivegreen: 0x556b2f,
-    darkorange: 0xff8c00,
-    darkorchid: 0x9932cc,
-    darkred: 0x8b0000,
-    darksalmon: 0xe9967a,
-    darkseagreen: 0x8fbc8f,
-    darkslateblue: 0x483d8b,
-    darkslategray: 0x2f4f4f,
-    darkturquoise: 0x00ced1,
-    darkviolet: 0x9400d3,
-    deeppink: 0xff1493,
-    deepskyblue: 0x00bfff,
-    dimgray: 0x696969,
-    dodgerblue: 0x1e90ff,
-    firebrick: 0xb22222,
-    floralwhite: 0xfffaf0,
-    forestgreen: 0x228b22,
-    fuchsia: 0xff00ff,
-    gainsboro: 0xdcdcdc,
-    ghostwhite: 0xf8f8ff,
-    gold: 0xffd700,
-    goldenrod: 0xdaa520,
-    gray: 0x808080,
-    green: 0x008000,
-    greenyellow: 0xadff2f,
-    honeydew: 0xf0fff0,
-    hotpink: 0xff69b4,
-    indianred: 0xcd5c5c,
-    indigo: 0x4b0082,
-    ivory: 0xfffff0,
-    khaki: 0xf0e68c,
-    lavender: 0xe6e6fa,
-    lavenderblush: 0xfff0f5,
-    lawngreen: 0x7cfc00,
-    lemonchiffon: 0xfffacd,
-    lightblue: 0xadd8e6,
-    lightcoral: 0xf08080,
-    lightcyan: 0xe0ffff,
-    lightgoldenrodyellow: 0xfafad2,
-    lightgrey: 0xd3d3d3,
-    lightgreen: 0x90ee90,
-    lightpink: 0xffb6c1,
-    lightsalmon: 0xffa07a,
-    lightseagreen: 0x20b2aa,
-    lightskyblue: 0x87cefa,
-    lightslategray: 0x778899,
-    lightsteelblue: 0xb0c4de,
-    lightyellow: 0xffffe0,
-    lime: 0x00ff00,
-    limegreen: 0x32cd32,
-    linen: 0xfaf0e6,
-    magenta: 0xff00ff,
-    maroon: 0x800000,
-    mediumaquamarine: 0x66cdaa,
-    mediumblue: 0x0000cd,
-    mediumorchid: 0xba55d3,
-    mediumpurple: 0x9370d8,
-    mediumseagreen: 0x3cb371,
-    mediumslateblue: 0x7b68ee,
-    mediumspringgreen: 0x00fa9a,
-    mediumturquoise: 0x48d1cc,
-    mediumvioletred: 0xc71585,
-    midnightblue: 0x191970,
-    mintcream: 0xf5fffa,
-    mistyrose: 0xffe4e1,
-    moccasin: 0xffe4b5,
-    navajowhite: 0xffdead,
-    navy: 0x000080,
-    oldlace: 0xfdf5e6,
-    olive: 0x808000,
-    olivedrab: 0x6b8e23,
-    orange: 0xffa500,
-    orangered: 0xff4500,
-    orchid: 0xda70d6,
-    palegoldenrod: 0xeee8aa,
-    palegreen: 0x98fb98,
-    paleturquoise: 0xafeeee,
-    palevioletred: 0xd87093,
-    papayawhip: 0xffefd5,
-    peachpuff: 0xffdab9,
-    peru: 0xcd853f,
-    pink: 0xffc0cb,
-    plum: 0xdda0dd,
-    powderblue: 0xb0e0e6,
-    purple: 0x800080,
-    red: 0xff0000,
-    rosybrown: 0xbc8f8f,
-    royalblue: 0x4169e1,
-    saddlebrown: 0x8b4513,
-    salmon: 0xfa8072,
-    sandybrown: 0xf4a460,
-    seagreen: 0x2e8b57,
-    seashell: 0xfff5ee,
-    sienna: 0xa0522d,
-    silver: 0xc0c0c0,
-    skyblue: 0x87ceeb,
-    slateblue: 0x6a5acd,
-    slategray: 0x708090,
-    snow: 0xfffafa,
-    springgreen: 0x00ff7f,
-    steelblue: 0x4682b4,
-    tan: 0xd2b48c,
-    teal: 0x008080,
-    thistle: 0xd8bfd8,
-    tomato: 0xff6347,
-    turquoise: 0x40e0d0,
-    violet: 0xee82ee,
-    wheat: 0xf5deb3,
-    white: 0xffffff,
-    whitesmoke: 0xf5f5f5,
-    yellow: 0xffff00,
-    yellowgreen: 0x9acd32
   }
+}
+
+/** Splits a declaration body into one style per style type. */
+function parseDeclaration(s: string): Style[] {
+  // Create styles
+  const ss = new ShapeStyle();
+  const ps = new PointStyle();
+  const ts = new TextStyle();
+  const hs = new ShieldStyle();
+  const xs = new InstructionStyle();
+
+  const assignments: Record<string, string> = {};
+  const isEval: Record<string, boolean> = {};
+  let o: RegExpExecArray | null;
+  for (const a of s.split(";")) {
+    if ((o = ASSIGNMENT_EVAL.exec(a))) {
+      const k = o[1].replace(DASH, "_");
+      assignments[k] = o[2];
+      isEval[k] = true;
+    } else if ((o = ASSIGNMENT.exec(a))) {
+      assignments[o[1].replace(DASH, "_")] = o[2];
+    } else if (SET_TAG_EVAL.exec(a)) {
+      // xs.addSetTag(o[1], saveEval(o[2]));
+    } else if ((o = SET_TAG.exec(a))) {
+      xs.addSetTag(o[1], o[2]);
+    } else if ((o = SET_TAG_TRUE.exec(a))) {
+      xs.addSetTag(o[1], true);
+    } else if (EXIT.exec(a)) {
+      xs.setPropertyFromString("breaker", true);
+    }
+  }
+
+  // Assign each property to the style that accepts it
+  for (const a in assignments) {
+    const style = [ss, ps, ts, hs].find((style) => style.has(a));
+    style?.setPropertyFromString(a, assignments[a], isEval[a]);
+  }
+
+  return [ss, ps, ts, hs, xs].filter((style) => style.edited);
+}
+
+/** Parses a `|z…` zoom range into its minimum and maximum zoom levels. */
+function parseZoom(s: string): [number, number] {
+  let o: RegExpExecArray | null;
+  if ((o = ZOOM_MINMAX.exec(s))) {
+    return [Number(o[1]), Number(o[2])];
+  } else if ((o = ZOOM_MIN.exec(s))) {
+    return [Number(o[1]), MAX_SCALE];
+  } else if ((o = ZOOM_MAX.exec(s))) {
+    return [MIN_SCALE, Number(o[1])];
+  } else if ((o = ZOOM_SINGLE.exec(s))) {
+    return [Number(o[1]), Number(o[1])];
+  }
+  return null;
+}
+
+/** Parses the body of a `[…]` selector into a {@link Condition}. */
+function parseCondition(s: string): Condition | null {
+  for (const [type, pattern] of CONDITIONS) {
+    const o = pattern.exec(s);
+    // The presence-testing patterns capture only a key, the comparing ones
+    // also capture a value.
+    if (o) return new Condition(type, ...o.slice(1).filter(Boolean));
+  }
+  return null;
+}
+
+const CSSCOLORS: Record<string, number> = {
+  aliceblue: 0xf0f8ff,
+  antiquewhite: 0xfaebd7,
+  aqua: 0x00ffff,
+  aquamarine: 0x7fffd4,
+  azure: 0xf0ffff,
+  beige: 0xf5f5dc,
+  bisque: 0xffe4c4,
+  black: 0x000000,
+  blanchedalmond: 0xffebcd,
+  blue: 0x0000ff,
+  blueviolet: 0x8a2be2,
+  brown: 0xa52a2a,
+  burlywood: 0xdeb887,
+  cadetblue: 0x5f9ea0,
+  chartreuse: 0x7fff00,
+  chocolate: 0xd2691e,
+  coral: 0xff7f50,
+  cornflowerblue: 0x6495ed,
+  cornsilk: 0xfff8dc,
+  crimson: 0xdc143c,
+  cyan: 0x00ffff,
+  darkblue: 0x00008b,
+  darkcyan: 0x008b8b,
+  darkgoldenrod: 0xb8860b,
+  darkgray: 0xa9a9a9,
+  darkgreen: 0x006400,
+  darkkhaki: 0xbdb76b,
+  darkmagenta: 0x8b008b,
+  darkolivegreen: 0x556b2f,
+  darkorange: 0xff8c00,
+  darkorchid: 0x9932cc,
+  darkred: 0x8b0000,
+  darksalmon: 0xe9967a,
+  darkseagreen: 0x8fbc8f,
+  darkslateblue: 0x483d8b,
+  darkslategray: 0x2f4f4f,
+  darkturquoise: 0x00ced1,
+  darkviolet: 0x9400d3,
+  deeppink: 0xff1493,
+  deepskyblue: 0x00bfff,
+  dimgray: 0x696969,
+  dodgerblue: 0x1e90ff,
+  firebrick: 0xb22222,
+  floralwhite: 0xfffaf0,
+  forestgreen: 0x228b22,
+  fuchsia: 0xff00ff,
+  gainsboro: 0xdcdcdc,
+  ghostwhite: 0xf8f8ff,
+  gold: 0xffd700,
+  goldenrod: 0xdaa520,
+  gray: 0x808080,
+  green: 0x008000,
+  greenyellow: 0xadff2f,
+  honeydew: 0xf0fff0,
+  hotpink: 0xff69b4,
+  indianred: 0xcd5c5c,
+  indigo: 0x4b0082,
+  ivory: 0xfffff0,
+  khaki: 0xf0e68c,
+  lavender: 0xe6e6fa,
+  lavenderblush: 0xfff0f5,
+  lawngreen: 0x7cfc00,
+  lemonchiffon: 0xfffacd,
+  lightblue: 0xadd8e6,
+  lightcoral: 0xf08080,
+  lightcyan: 0xe0ffff,
+  lightgoldenrodyellow: 0xfafad2,
+  lightgrey: 0xd3d3d3,
+  lightgreen: 0x90ee90,
+  lightpink: 0xffb6c1,
+  lightsalmon: 0xffa07a,
+  lightseagreen: 0x20b2aa,
+  lightskyblue: 0x87cefa,
+  lightslategray: 0x778899,
+  lightsteelblue: 0xb0c4de,
+  lightyellow: 0xffffe0,
+  lime: 0x00ff00,
+  limegreen: 0x32cd32,
+  linen: 0xfaf0e6,
+  magenta: 0xff00ff,
+  maroon: 0x800000,
+  mediumaquamarine: 0x66cdaa,
+  mediumblue: 0x0000cd,
+  mediumorchid: 0xba55d3,
+  mediumpurple: 0x9370d8,
+  mediumseagreen: 0x3cb371,
+  mediumslateblue: 0x7b68ee,
+  mediumspringgreen: 0x00fa9a,
+  mediumturquoise: 0x48d1cc,
+  mediumvioletred: 0xc71585,
+  midnightblue: 0x191970,
+  mintcream: 0xf5fffa,
+  mistyrose: 0xffe4e1,
+  moccasin: 0xffe4b5,
+  navajowhite: 0xffdead,
+  navy: 0x000080,
+  oldlace: 0xfdf5e6,
+  olive: 0x808000,
+  olivedrab: 0x6b8e23,
+  orange: 0xffa500,
+  orangered: 0xff4500,
+  orchid: 0xda70d6,
+  palegoldenrod: 0xeee8aa,
+  palegreen: 0x98fb98,
+  paleturquoise: 0xafeeee,
+  palevioletred: 0xd87093,
+  papayawhip: 0xffefd5,
+  peachpuff: 0xffdab9,
+  peru: 0xcd853f,
+  pink: 0xffc0cb,
+  plum: 0xdda0dd,
+  powderblue: 0xb0e0e6,
+  purple: 0x800080,
+  red: 0xff0000,
+  rosybrown: 0xbc8f8f,
+  royalblue: 0x4169e1,
+  saddlebrown: 0x8b4513,
+  salmon: 0xfa8072,
+  sandybrown: 0xf4a460,
+  seagreen: 0x2e8b57,
+  seashell: 0xfff5ee,
+  sienna: 0xa0522d,
+  silver: 0xc0c0c0,
+  skyblue: 0x87ceeb,
+  slateblue: 0x6a5acd,
+  slategray: 0x708090,
+  snow: 0xfffafa,
+  springgreen: 0x00ff7f,
+  steelblue: 0x4682b4,
+  tan: 0xd2b48c,
+  teal: 0x008080,
+  thistle: 0xd8bfd8,
+  tomato: 0xff6347,
+  turquoise: 0x40e0d0,
+  violet: 0xee82ee,
+  wheat: 0xf5deb3,
+  white: 0xffffff,
+  whitesmoke: 0xf5f5f5,
+  yellow: 0xffff00,
+  yellowgreen: 0x9acd32
 };

--- a/js/jsmapcss/ShapeStyle.ts
+++ b/js/jsmapcss/ShapeStyle.ts
@@ -49,10 +49,7 @@ export class ShapeStyle extends Style {
 
   override drawn(): boolean {
     return Boolean(
-      this.fill_image ||
-      !isNaN(Number(this.fill_color)) ||
-      this.width ||
-      this.casing_width
+      this.fill_image || this.fill_color || this.width || this.casing_width
     );
   }
 

--- a/js/jsmapcss/ShapeStyle.ts
+++ b/js/jsmapcss/ShapeStyle.ts
@@ -1,30 +1,51 @@
-import {Style, prototypeDefaults} from "./Style";
+import {Style} from "./Style";
 
 /** How a feature's geometry is stroked and filled. */
 export class ShapeStyle extends Style {
-  declare width: number;
-  declare offset: number;
-  declare color: string | null;
-  declare opacity: number;
-  declare dashes: number[];
-  declare linecap: string | null;
-  declare linejoin: string | null;
-  declare line_style: string | null;
-  declare fill_image: string | null;
-  declare fill_color: string | null;
-  declare fill_opacity: number;
-  declare casing_width: number;
-  declare casing_color: string | null;
-  declare casing_opacity: number;
-  declare casing_dashes: number[];
+  override styleType = "ShapeStyle";
+  override properties = [
+    "width",
+    "offset",
+    "color",
+    "opacity",
+    "dashes",
+    "linecap",
+    "linejoin",
+    "line_style",
+    "fill_image",
+    "fill_color",
+    "fill_opacity",
+    "casing_width",
+    "casing_color",
+    "casing_opacity",
+    "casing_dashes",
+    "layer",
+    "render"
+  ];
+
+  width = 0;
+  offset = NaN;
+  color: string | null = null;
+  opacity = NaN;
+  dashes: number[] = [];
+  linecap: string | null = null;
+  linejoin: string | null = null;
+  line_style: string | null = null;
+  fill_image: string | null = null;
+  fill_color: string | null = null;
+  fill_opacity = NaN;
+  casing_width = NaN;
+  casing_color: string | null = null;
+  casing_opacity = NaN;
+  casing_dashes: number[] = [];
   /** Optional layer override, usually set by the OSM `layer` tag. */
-  declare layer: number;
+  layer = NaN;
   /**
    * `auto` allows line and area features to be drawn as points at low zoom
    * levels, `native` always uses the feature's own geometry type, and `point`
    * always draws the feature at the centroid of its geometry.
    */
-  declare render: string | null;
+  render: string | null = null;
 
   override drawn(): boolean {
     return Boolean(
@@ -44,43 +65,3 @@ export class ShapeStyle extends Style {
     return this.width + (this.casing_width ? this.casing_width * 2 : 0);
   }
 }
-
-prototypeDefaults(ShapeStyle, {
-  styleType: "ShapeStyle",
-  properties: [
-    "width",
-    "offset",
-    "color",
-    "opacity",
-    "dashes",
-    "linecap",
-    "linejoin",
-    "line_style",
-    "fill_image",
-    "fill_color",
-    "fill_opacity",
-    "casing_width",
-    "casing_color",
-    "casing_opacity",
-    "casing_dashes",
-    "layer",
-    "render"
-  ],
-  width: 0,
-  offset: NaN,
-  color: null,
-  opacity: NaN,
-  dashes: [],
-  linecap: null,
-  linejoin: null,
-  line_style: null,
-  fill_image: null,
-  fill_color: null,
-  fill_opacity: NaN,
-  casing_width: NaN,
-  casing_color: null,
-  casing_opacity: NaN,
-  casing_dashes: [],
-  layer: NaN,
-  render: null
-});

--- a/js/jsmapcss/ShapeStyle.ts
+++ b/js/jsmapcss/ShapeStyle.ts
@@ -1,0 +1,86 @@
+import {Style, prototypeDefaults} from "./Style";
+
+/** How a feature's geometry is stroked and filled. */
+export class ShapeStyle extends Style {
+  declare width: number;
+  declare offset: number;
+  declare color: string | null;
+  declare opacity: number;
+  declare dashes: number[];
+  declare linecap: string | null;
+  declare linejoin: string | null;
+  declare line_style: string | null;
+  declare fill_image: string | null;
+  declare fill_color: string | null;
+  declare fill_opacity: number;
+  declare casing_width: number;
+  declare casing_color: string | null;
+  declare casing_opacity: number;
+  declare casing_dashes: number[];
+  /** Optional layer override, usually set by the OSM `layer` tag. */
+  declare layer: number;
+  /**
+   * `auto` allows line and area features to be drawn as points at low zoom
+   * levels, `native` always uses the feature's own geometry type, and `point`
+   * always draws the feature at the centroid of its geometry.
+   */
+  declare render: string | null;
+
+  override drawn(): boolean {
+    return Boolean(
+      this.fill_image ||
+      !isNaN(Number(this.fill_color)) ||
+      this.width ||
+      this.casing_width
+    );
+  }
+
+  maxwidth(): number {
+    // If width is set by an eval, then we can't use it to calculate maxwidth,
+    // or it'll just grow on each invocation...
+    if (this.evals.width || this.evals.casing_width) {
+      return 0;
+    }
+    return this.width + (this.casing_width ? this.casing_width * 2 : 0);
+  }
+}
+
+prototypeDefaults(ShapeStyle, {
+  styleType: "ShapeStyle",
+  properties: [
+    "width",
+    "offset",
+    "color",
+    "opacity",
+    "dashes",
+    "linecap",
+    "linejoin",
+    "line_style",
+    "fill_image",
+    "fill_color",
+    "fill_opacity",
+    "casing_width",
+    "casing_color",
+    "casing_opacity",
+    "casing_dashes",
+    "layer",
+    "render"
+  ],
+  width: 0,
+  offset: NaN,
+  color: null,
+  opacity: NaN,
+  dashes: [],
+  linecap: null,
+  linejoin: null,
+  line_style: null,
+  fill_image: null,
+  fill_color: null,
+  fill_opacity: NaN,
+  casing_width: NaN,
+  casing_color: null,
+  casing_opacity: NaN,
+  casing_dashes: [],
+  layer: NaN,
+  render: null
+});

--- a/js/jsmapcss/ShieldStyle.ts
+++ b/js/jsmapcss/ShieldStyle.ts
@@ -1,16 +1,11 @@
-import {Style, prototypeDefaults} from "./Style";
+import {Style} from "./Style";
 
 /** The shield image drawn behind a feature's label. */
 export class ShieldStyle extends Style {
-  declare shield_image: string | null;
-  declare shield_width: number;
-  declare shield_height: number;
-}
+  override styleType = "ShieldStyle";
+  override properties = ["shield_image", "shield_width", "shield_height"];
 
-prototypeDefaults(ShieldStyle, {
-  styleType: "ShieldStyle",
-  properties: ["shield_image", "shield_width", "shield_height"],
-  shield_image: null,
-  shield_width: NaN,
-  shield_height: NaN
-});
+  shield_image: string | null = null;
+  shield_width = NaN;
+  shield_height = NaN;
+}

--- a/js/jsmapcss/ShieldStyle.ts
+++ b/js/jsmapcss/ShieldStyle.ts
@@ -1,0 +1,16 @@
+import {Style, prototypeDefaults} from "./Style";
+
+/** The shield image drawn behind a feature's label. */
+export class ShieldStyle extends Style {
+  declare shield_image: string | null;
+  declare shield_width: number;
+  declare shield_height: number;
+}
+
+prototypeDefaults(ShieldStyle, {
+  styleType: "ShieldStyle",
+  properties: ["shield_image", "shield_width", "shield_height"],
+  shield_image: null,
+  shield_width: NaN,
+  shield_height: NaN
+});

--- a/js/jsmapcss/Style.ts
+++ b/js/jsmapcss/Style.ts
@@ -1,407 +1,106 @@
+/*! this is mostly based on work by Richard Fairhurst, initially developed for iD editor, but abbandoned. See: http://lists.openstreetmap.org/pipermail/mapcss/2013-February/000341.html . This is under WTFPL. */
+
 import evalparser from "./eval.pegjs";
 
-const styleparser = {};
-styleparser.Style = function () {
-  this.__init__();
-};
+/** The tags of the OSM feature a style is being evaluated against. */
+export type Tags = Record<string, string>;
 
-styleparser.Style.prototype = {
-  merged: false,
-  edited: false,
-  //sublayer: 5, // TODO: commented out. see RuleSet.js
-  //interactive: true, // TODO: commented out. see RuleSet.js
-  properties: [],
-  styleType: "Style",
-  evals: {},
+/** A value a MapCSS declaration can assign to a style property. */
+export type StyleValue = string | number | boolean | number[];
 
-  __init__() {
-    this.evals = {};
-  },
+/**
+ * Assigns the default values of a style's properties to its prototype.
+ *
+ * The defaults deliberately do *not* live on the instances: `StyleChooser`
+ * copies only own properties into a `StyleList`, so a style carries nothing
+ * but the properties its declaration actually set. That is what allows two
+ * declarations matching the same feature to be merged without the later one
+ * overwriting the earlier one with its own defaults.
+ */
+export function prototypeDefaults<T>(
+  style: {prototype: T},
+  defaults: Partial<T>
+): void {
+  Object.assign(style.prototype, defaults);
+}
 
-  drawn() {
+/** Base class of the MapCSS style types, holding the shared property plumbing. */
+export class Style {
+  /** Names of the MapCSS properties this style type accepts. */
+  declare properties: string[];
+  declare styleType: string;
+  /** Whether any property has been assigned by a declaration. */
+  declare edited: boolean;
+  /** MapCSS `eval()` expressions by property name, evaluated per feature. */
+  evals: Record<string, string> = {};
+
+  /** Whether a feature carrying this style is visible on the map. */
+  drawn(): boolean {
     return false;
-  },
+  }
 
-  has(k) {
+  /** Whether this style type accepts the MapCSS property `k`. */
+  has(k: string): boolean {
     return this.properties.indexOf(k) > -1;
-  },
+  }
 
-  mergeWith(additional) {
-    for (const prop in this.properties) {
-      if (additional[prop]) {
-        this[prop] = additional[prop];
-      }
-    }
-    this.merged = true;
-  },
-
-  setPropertyFromString(k, v, isEval) {
+  /**
+   * Assigns a property parsed out of a MapCSS declaration, coercing it to the
+   * type of the property's default value.
+   */
+  setPropertyFromString(k: string, v: StyleValue, isEval?: boolean): void {
     this.edited = true;
     if (isEval) {
-      this.evals[k] = v;
+      this.evals[k] = String(v);
       return;
     }
 
-    if (typeof this[k] == "boolean") {
+    // Properties are addressed by name from the stylesheet, so this has to go
+    // through an index signature rather than the declared fields.
+    const properties = this as unknown as Record<string, StyleValue>;
+    const current = properties[k];
+    if (typeof current == "boolean") {
       v = Boolean(v);
-    } else if (typeof this[k] == "number") {
+    } else if (typeof current == "number") {
       v = Number(v);
-    } else if (this[k] && this[k].constructor == Array) {
-      v = v.split(",").map((a) => Number(a));
+    } else if (Array.isArray(current)) {
+      v = String(v)
+        .split(",")
+        .map((a) => Number(a));
     }
-    this[k] = v;
-    return true;
-  },
+    properties[k] = v;
+  }
 
-  runEvals(tags) {
-    // helper object for eval() properties
+  /** Resolves this style's `eval()` properties against a feature's tags. */
+  runEvals(tags: Tags): void {
     for (const k in this.evals) {
       try {
         const evaluated = evalparser.parse(this.evals[k], {
-          osm_tag: (t) => tags[t] || ""
-        });
+          osm_tag: (t: string) => tags[t] || ""
+        }) as string;
         this.setPropertyFromString(k, evaluated);
       } catch (e) {
         console.error("Error while evaluating mapcss evals", e);
       }
     }
-  },
-
-  toString() {
-    let str = "";
-    for (const k in this.properties) {
-      // eslint-disable-next-line no-prototype-builtins
-      if (this.hasOwnProperty(k)) {
-        str += `${k}=${this[k]}; `;
-      }
-    }
-    return str;
   }
-};
-styleparser.inherit_from_Style = function (target) {
-  for (const p in styleparser.Style.prototype)
-    if (target[p] === undefined) target[p] = styleparser.Style.prototype[p];
-};
 
-// ----------------------------------------------------------------------
-// InstructionStyle class
-
-styleparser.InstructionStyle = function () {
-  this.__init__();
-};
-styleparser.InstructionStyle.prototype = {
-  set_tags: null,
-  breaker: false,
-  styleType: "InstructionStyle",
-
-  __init__() {},
-
-  addSetTag(k, v) {
-    this.edited = true;
-    if (!this.set_tags) this.set_tags = {};
-    this.set_tags[k] = v;
+  toString(): string {
+    const properties = this as unknown as Record<string, StyleValue>;
+    return this.properties
+      .filter((k) => Object.hasOwn(this, k))
+      .map((k) => `${k}=${properties[k]}; `)
+      .join("");
   }
-};
-styleparser.inherit_from_Style(styleparser.InstructionStyle.prototype);
+}
 
-// ----------------------------------------------------------------------
-// PointStyle class
+prototypeDefaults(Style, {
+  properties: [],
+  styleType: "Style",
+  edited: false
+});
 
-styleparser.PointStyle = function () {
-  this.__init__();
-};
-styleparser.PointStyle.prototype = {
-  properties: [
-    "icon_image",
-    "icon_width",
-    "icon_height",
-    "icon_opacity",
-    "rotation"
-  ],
-  icon_image: null,
-  icon_width: 0,
-  icon_height: NaN,
-  rotation: NaN,
-  styleType: "PointStyle",
-
-  drawn() {
-    return this.icon_image !== null;
-  },
-
-  maxwidth() {
-    return this.evals.icon_width ? 0 : this.icon_width;
-  }
-};
-styleparser.inherit_from_Style(styleparser.PointStyle.prototype);
-
-// ----------------------------------------------------------------------
-// ShapeStyle class
-
-styleparser.ShapeStyle = function () {
-  this.__init__();
-};
-
-styleparser.ShapeStyle.prototype = {
-  properties: [
-    "width",
-    "offset",
-    "color",
-    "opacity",
-    "dashes",
-    "linecap",
-    "linejoin",
-    "line_style",
-    "fill_image",
-    "fill_color",
-    "fill_opacity",
-    "casing_width",
-    "casing_color",
-    "casing_opacity",
-    "casing_dashes",
-    "layer",
-    "render"
-  ],
-
-  width: 0,
-  color: null,
-  opacity: NaN,
-  dashes: [],
-  linecap: null,
-  linejoin: null,
-  line_style: null,
-  fill_image: null,
-  fill_color: null,
-  fill_opacity: NaN,
-  casing_width: NaN,
-  casing_color: null,
-  casing_opacity: NaN,
-  casing_dashes: [],
-  layer: NaN, // optional layer override (usually set by OSM tag)
-  render: null, // "auto" indicates that line/area features are allowed to be rendered as points on low zoom levels; the value "native" always renders features using their native geometry type; the value "point" always renders features as points in the centroid of the feature geometry
-  styleType: "ShapeStyle",
-
-  drawn() {
-    return (
-      this.fill_image ||
-      !isNaN(this.fill_color) ||
-      this.width ||
-      this.casing_width
-    );
-  },
-  maxwidth() {
-    // If width is set by an eval, then we can't use it to calculate maxwidth, or it'll just grow on each invocation...
-    if (this.evals.width || this.evals.casing_width) {
-      return 0;
-    }
-    return this.width + (this.casing_width ? this.casing_width * 2 : 0);
-  },
-  strokeStyler() {
-    let cap, join;
-    switch (this.linecap) {
-      case "round":
-        cap = "round";
-        break;
-      case "square":
-        cap = "square";
-        break;
-      default:
-        cap = "butt";
-        break;
-    }
-    switch (this.linejoin) {
-      case "bevel":
-        join = "bevel";
-        break;
-      case "miter":
-        join = 4;
-        break;
-      default:
-        join = "round";
-        break;
-    }
-    return {
-      color: this.dojoColor(
-        this.color ? this.color : 0,
-        this.opacity ? this.opacity : 1
-      ),
-      style: "Solid", // needs to parse dashes
-      width: this.width,
-      cap: cap,
-      join: join
-    };
-  },
-  shapeStrokeStyler() {
-    if (isNaN(this.casing_color)) {
-      return {width: 0};
-    }
-    return {
-      color: this.dojoColor(
-        this.casing_color,
-        this.casing_opacity ? this.casing_opacity : 1
-      ),
-      width: this.casing_width ? this.casing_width : 1
-    };
-  },
-  shapeFillStyler() {
-    if (isNaN(this.color)) {
-      return null;
-    }
-    return this.dojoColor(this.color, this.opacity ? this.opacity : 1);
-  },
-  fillStyler() {
-    return this.dojoColor(
-      this.fill_color,
-      this.fill_opacity ? this.fill_opacity : 1
-    );
-  },
-  casingStyler() {
-    let cap, join;
-    switch (this.linecap) {
-      case "round":
-        cap = "round";
-        break;
-      case "square":
-        cap = "square";
-        break;
-      default:
-        cap = "butt";
-        break;
-    }
-    switch (this.linejoin) {
-      case "bevel":
-        join = "bevel";
-        break;
-      case "miter":
-        join = 4;
-        break;
-      default:
-        join = "round";
-        break;
-    }
-    return {
-      color: this.dojoColor(
-        this.casing_color ? this.casing_color : 0,
-        this.casing_opacity ? this.casing_opacity : 1
-      ),
-      width: this.width + this.casing_width * 2,
-      style: "Solid",
-      cap: cap,
-      join: join
-    };
-  }
-};
-styleparser.inherit_from_Style(styleparser.ShapeStyle.prototype);
-
-// ----------------------------------------------------------------------
-// TextStyle class
-
-styleparser.TextStyle = function () {
-  this.__init__();
-};
-styleparser.TextStyle.prototype = {
-  properties: [
-    "font_family",
-    "font_size",
-    "font_style",
-    "font_variant",
-    "font_weight",
-    "max_width",
-    "shield_casing_color",
-    "shield_casing_width",
-    "shield_color",
-    "shield_frame_color",
-    "shield_frame_width",
-    "shield_image",
-    "shield_opacity",
-    "shield_shape",
-    "shield_text",
-    "text_color",
-    "text_decoration",
-    "text_halo_color",
-    "text_halo_radius",
-    "text_offset",
-    "text_opacity",
-    "text_position",
-    "text_transform",
-    "text"
-  ],
-
-  font_family: null,
-  font_size: null,
-  font_style: null,
-  font_variant: null,
-  font_weight: null,
-  max_width: null,
-  shield_casing_color: null,
-  shield_casing_width: null,
-  shield_color: null,
-  shield_frame_color: null,
-  shield_frame_width: null,
-  shield_image: null,
-  shield_opacity: null,
-  shield_shape: null,
-  shield_text: null,
-  text_color: null,
-  text_decoration: null,
-  text_halo_color: null,
-  text_halo_radius: 0,
-  text_offset: null,
-  text_opacity: null,
-  text_position: null,
-  text_transform: null,
-  text: null,
-
-  styleType: "TextStyle",
-
-  textStyleAsCSS(): string {
-    return styleString({
-      borderColor: this.shield_frame_color,
-      borderStyle: this.shield_frame_color ? "solid" : null,
-      borderWidth: this.shield_frame_width,
-      backgroundColor: this.shield_color,
-      fontFamily: this.font_family,
-      fontSize: this.font_size,
-      fontStyle: this.font_style,
-      fontVariant: this.font_variant,
-      fontWeight: this.font_weight,
-      maxWidth: this.max_width,
-      color: this.text_color,
-      textDecoration: this.text_decoration,
-      textShadow:
-        this.text_halo_color && this.text_halo_radius > 0
-          ? `0 0 ${this.text_halo_radius}px ${this.text_halo_color}`
-          : null,
-      opacity: this.text_opacity,
-      transform: this.text_transform
-    });
-  }
-};
-styleparser.inherit_from_Style(styleparser.TextStyle.prototype);
-
-// ----------------------------------------------------------------------
-// ShieldStyle class
-
-styleparser.ShieldStyle = function () {
-  this.__init__();
-};
-
-styleparser.ShieldStyle.prototype = {
-  has(k) {
-    return this.properties.indexOf(k) > -1;
-  },
-  properties: ["shield_image", "shield_width", "shield_height"],
-  shield_image: null,
-  shield_width: NaN,
-  shield_height: NaN,
-  styleType: "ShieldStyle"
-};
-styleparser.inherit_from_Style(styleparser.ShieldStyle.prototype);
-
-// ----------------------------------------------------------------------
-// End of module
-
-export default styleparser;
-
+/** Serialises a style declaration to an inline CSS `style` attribute value. */
 export function styleString(style: Partial<CSSStyleDeclaration>) {
   return Object.entries(style)
     .filter(([_key, value]) => value !== null && value !== undefined)

--- a/js/jsmapcss/Style.ts
+++ b/js/jsmapcss/Style.ts
@@ -2,8 +2,15 @@
 
 import evalparser from "./eval.pegjs";
 
-/** The tags of the OSM feature a style is being evaluated against. */
-export type Tags = Record<string, string>;
+/**
+ * The tags of the OSM feature a style is being evaluated against.
+ *
+ * OSM's own tags are strings, but the values are not all strings: overpass
+ * turbo adds pseudo-tags such as `:tagged` and `:placeholder` as booleans, and
+ * styling injects the running `_width` as a number. Conditions compare
+ * loosely, so these work wherever a string would.
+ */
+export type Tags = Record<string, string | number | boolean>;
 
 /** A value a MapCSS declaration can assign to a style property. */
 export type StyleValue = string | number | boolean | number[];

--- a/js/jsmapcss/Style.ts
+++ b/js/jsmapcss/Style.ts
@@ -8,31 +8,24 @@ export type Tags = Record<string, string>;
 /** A value a MapCSS declaration can assign to a style property. */
 export type StyleValue = string | number | boolean | number[];
 
-/**
- * Assigns the default values of a style's properties to its prototype.
- *
- * The defaults deliberately do *not* live on the instances: `StyleChooser`
- * copies only own properties into a `StyleList`, so a style carries nothing
- * but the properties its declaration actually set. That is what allows two
- * declarations matching the same feature to be merged without the later one
- * overwriting the earlier one with its own defaults.
- */
-export function prototypeDefaults<T>(
-  style: {prototype: T},
-  defaults: Partial<T>
-): void {
-  Object.assign(style.prototype, defaults);
-}
-
 /** Base class of the MapCSS style types, holding the shared property plumbing. */
 export class Style {
   /** Names of the MapCSS properties this style type accepts. */
-  declare properties: string[];
-  declare styleType: string;
+  properties: string[] = [];
+  styleType = "Style";
   /** Whether any property has been assigned by a declaration. */
-  declare edited: boolean;
+  edited = false;
   /** MapCSS `eval()` expressions by property name, evaluated per feature. */
   evals: Record<string, string> = {};
+  /**
+   * The properties a declaration actually assigned, as opposed to those still
+   * holding their default.
+   *
+   * A style contributes only these to a {@link StyleList}, so that two
+   * declarations matching the same feature can be merged without the later one
+   * overwriting the earlier one with defaults it was never asked for.
+   */
+  readonly assigned = new Set<string>();
 
   /** Whether a feature carrying this style is visible on the map. */
   drawn(): boolean {
@@ -69,6 +62,22 @@ export class Style {
         .map((a) => Number(a));
     }
     properties[k] = v;
+    this.assigned.add(k);
+  }
+
+  /**
+   * The part of this style a declaration established, ready to be merged into
+   * a {@link StyleList}.
+   *
+   * `evals` comes along unconditionally: consumers read it to tell a literal
+   * value apart from one computed per feature.
+   */
+  assignedProperties(): Partial<this> {
+    const properties = this as unknown as Record<string, StyleValue>;
+    return {
+      evals: this.evals,
+      ...Object.fromEntries([...this.assigned].map((k) => [k, properties[k]]))
+    } as Partial<this>;
   }
 
   /** Resolves this style's `eval()` properties against a feature's tags. */
@@ -88,17 +97,11 @@ export class Style {
   toString(): string {
     const properties = this as unknown as Record<string, StyleValue>;
     return this.properties
-      .filter((k) => Object.hasOwn(this, k))
+      .filter((k) => this.assigned.has(k))
       .map((k) => `${k}=${properties[k]}; `)
       .join("");
   }
 }
-
-prototypeDefaults(Style, {
-  properties: [],
-  styleType: "Style",
-  edited: false
-});
 
 /** Serialises a style declaration to an inline CSS `style` attribute value. */
 export function styleString(style: Partial<CSSStyleDeclaration>) {

--- a/js/jsmapcss/StyleChooser.ts
+++ b/js/jsmapcss/StyleChooser.ts
@@ -90,13 +90,12 @@ export class StyleChooser {
         (tags as InjectedTags)._width = sl.maxwidth;
 
         r.runEvals(tags);
-        // Spreading takes only own properties, so a style contributes just what
-        // its declaration set — its defaults stay behind on its prototype and
-        // cannot overwrite what an earlier declaration already established.
-        // The result must stay a plain object: consumers read a property as
-        // absent when it is `undefined`, which inheriting the defaults would
-        // defeat.
-        a[c.subpart] = {...a[c.subpart], ...r};
+        // Only the properties this declaration assigned are merged in, so it
+        // cannot overwrite what an earlier one established with defaults it was
+        // never asked for. The result stays a plain object: consumers read a
+        // property as absent when it is `undefined`, which inheriting the
+        // defaults would defeat.
+        a[c.subpart] = {...a[c.subpart], ...r.assignedProperties()};
       }
     }
   }

--- a/js/jsmapcss/StyleChooser.ts
+++ b/js/jsmapcss/StyleChooser.ts
@@ -1,110 +1,103 @@
-// styleparser/StyleChooser.js
+import {InstructionStyle} from "./InstructionStyle";
+import {PointStyle} from "./PointStyle";
+import type {Entity} from "./Rule";
+import {RuleChain} from "./RuleChain";
+import {ShapeStyle} from "./ShapeStyle";
+import type {Style, Tags} from "./Style";
+import type {StyleList, SubpartStyles} from "./StyleList";
 
-import styleparser from "./Style";
+/**
+ * Tags as seen while a stylesheet is being applied.
+ *
+ * Styling injects values that are not strings — the running `_width`, and the
+ * booleans recorded by `set foo` — which conditions and `eval()` expressions
+ * then coerce as needed.
+ */
+type InjectedTags = Record<string, string | number | boolean>;
 
-styleparser.StyleChooser = function () {
-  this.ruleChains = [new styleparser.RuleChain()];
-  this.styles = [];
-};
+/**
+ * A combination of selectors and a declaration. For example,
+ * `way[highway=footway] node[barrier=gate] { icon: gate.png; }` is one
+ * StyleChooser.
+ */
+export class StyleChooser {
+  /** The selectors, each one a chain of rules. */
+  ruleChains: RuleChain[] = [new RuleChain()];
+  /** The declaration, parsed into one style per style type. */
+  styles: Style[] = [];
+  /** Are any of the rules zoom-specific? */
+  zoomSpecific = false;
 
-styleparser.StyleChooser.prototype = {
-  // UpdateStyles doesn't support image-widths yet
-  // or setting maxwidth/_width
-  ruleChains: [], // array of RuleChains (each one an array of Rules)
-  styles: [], // array of ShapeStyle/ShieldStyle/TextStyle/PointStyle
-  zoomSpecific: false, // are any of the rules zoom-specific?
-
-  rcpos: 0,
-  stylepos: 0,
-
-  constructor() {
-    // summary:		A combination of the selectors (ruleChains) and declaration (styles).
-    //				For example, way[highway=footway] node[barrier=gate] { icon: gate.png; } is one StyleChooser.
-  },
-
-  currentChain() {
+  currentChain(): RuleChain {
     return this.ruleChains[this.ruleChains.length - 1];
-  },
+  }
 
-  newRuleChain() {
-    // summary:		Starts a new ruleChain in this.ruleChains.
-    if (this.ruleChains[this.ruleChains.length - 1].length() > 0) {
-      this.ruleChains.push(new styleparser.RuleChain());
+  /** Starts a new rule chain, unless the current one is still empty. */
+  newRuleChain(): void {
+    if (this.currentChain().length() > 0) {
+      this.ruleChains.push(new RuleChain());
     }
-  },
+  }
 
-  addStyles(a) {
+  addStyles(a: Style[]): void {
     this.styles = this.styles.concat(a);
-  },
+  }
 
-  updateStyles(entity, tags, sl, zoom) {
+  /** Adds this chooser's styles to `sl` if any of its selectors match. */
+  updateStyles(entity: Entity, tags: Tags, sl: StyleList, zoom: number): void {
     if (this.zoomSpecific) {
       sl.validAt = zoom;
     }
 
-    // Are any of the ruleChains fulfilled?
-    for (const i in this.ruleChains) {
-      const c = this.ruleChains[i];
-      if (c.test(-1, entity, tags, zoom)) {
-        sl.addSubpart(c.subpart);
+    for (const c of this.ruleChains) {
+      if (!c.test(-1, entity, tags, zoom)) continue;
+      sl.addSubpart(c.subpart);
 
-        // Update StyleList
-        for (const j in this.styles) {
-          const r = this.styles[j];
-          let a;
-          switch (r.styleType) {
-            case "ShapeStyle":
-              sl.maxwidth = Math.max(sl.maxwidth, r.maxwidth());
-              a = sl.shapeStyles;
-              break;
-            case "ShieldStyle":
-              a = sl.shieldStyles;
-              break;
-            case "TextStyle":
-              a = sl.textStyles;
-              break;
-            case "PointStyle":
-              sl.maxwidth = Math.max(sl.maxwidth, r.maxwidth());
-              a = sl.pointStyles;
-              break;
-            case "InstructionStyle":
-              if (r.breaker) {
-                return;
-              }
-              for (const k in r.set_tags) {
-                tags[k] = r.set_tags[k];
-              }
-              a = {}; // "dev/null" stylechooser reciever
-              break;
-          }
-          if (r.drawn()) {
-            tags[":drawn"] = "yes";
-          }
-          tags._width = sl.maxwidth;
-
-          r.runEvals(tags);
-          // helper function
-          if (a[c.subpart]) {
-            // // If there's already a style on this sublayer, then merge them
-            // // (making a deep copy if necessary to avoid altering the root style)
-            // if (!a[c.subpart].merged) { a[c.subpart]=extend({},a[c.subpart]); }
-            extend(a[c.subpart], r);
-          } else {
-            // // Otherwise, just assign it
-            a[c.subpart] = extend({}, r);
+      for (const r of this.styles) {
+        let a: SubpartStyles<Style>;
+        switch (r.styleType) {
+          case "ShapeStyle":
+            sl.maxwidth = Math.max(sl.maxwidth, (r as ShapeStyle).maxwidth());
+            a = sl.shapeStyles;
+            break;
+          case "ShieldStyle":
+            a = sl.shieldStyles;
+            break;
+          case "TextStyle":
+            a = sl.textStyles;
+            break;
+          case "PointStyle":
+            sl.maxwidth = Math.max(sl.maxwidth, (r as PointStyle).maxwidth());
+            a = sl.pointStyles;
+            break;
+          case "InstructionStyle": {
+            const instruction = r as InstructionStyle;
+            if (instruction.breaker) {
+              return;
+            }
+            // `set foo` records a boolean rather than a string, which
+            // conditions then compare against loosely.
+            for (const k in instruction.set_tags) {
+              (tags as InjectedTags)[k] = instruction.set_tags[k];
+            }
+            a = {}; // "dev/null" stylechooser reciever
+            break;
           }
         }
+        if (r.drawn()) {
+          tags[":drawn"] = "yes";
+        }
+        (tags as InjectedTags)._width = sl.maxwidth;
+
+        r.runEvals(tags);
+        // Spreading takes only own properties, so a style contributes just what
+        // its declaration set — its defaults stay behind on its prototype and
+        // cannot overwrite what an earlier declaration already established.
+        // The result must stay a plain object: consumers read a property as
+        // absent when it is `undefined`, which inheriting the defaults would
+        // defeat.
+        a[c.subpart] = {...a[c.subpart], ...r};
       }
     }
   }
-};
-
-function extend(destination, source) {
-  for (const property in source) {
-    // eslint-disable-next-line no-prototype-builtins
-    if (source.hasOwnProperty(property)) {
-      destination[property] = source[property];
-    }
-  }
-  return destination;
 }

--- a/js/jsmapcss/StyleChooser.ts
+++ b/js/jsmapcss/StyleChooser.ts
@@ -7,15 +7,6 @@ import type {Style, Tags} from "./Style";
 import type {StyleList, SubpartStyles} from "./StyleList";
 
 /**
- * Tags as seen while a stylesheet is being applied.
- *
- * Styling injects values that are not strings — the running `_width`, and the
- * booleans recorded by `set foo` — which conditions and `eval()` expressions
- * then coerce as needed.
- */
-type InjectedTags = Record<string, string | number | boolean>;
-
-/**
  * A combination of selectors and a declaration. For example,
  * `way[highway=footway] node[barrier=gate] { icon: gate.png; }` is one
  * StyleChooser.
@@ -78,7 +69,7 @@ export class StyleChooser {
             // `set foo` records a boolean rather than a string, which
             // conditions then compare against loosely.
             for (const k in instruction.set_tags) {
-              (tags as InjectedTags)[k] = instruction.set_tags[k];
+              tags[k] = instruction.set_tags[k];
             }
             a = {}; // "dev/null" stylechooser reciever
             break;
@@ -87,7 +78,7 @@ export class StyleChooser {
         if (r.drawn()) {
           tags[":drawn"] = "yes";
         }
-        (tags as InjectedTags)._width = sl.maxwidth;
+        tags._width = sl.maxwidth;
 
         r.runEvals(tags);
         // Only the properties this declaration assigned are merged in, so it

--- a/js/jsmapcss/StyleList.ts
+++ b/js/jsmapcss/StyleList.ts
@@ -1,102 +1,87 @@
-// ----------------------------------------------------------------------
-// StyleList class
+import type {PointStyle} from "./PointStyle";
+import type {ShapeStyle} from "./ShapeStyle";
+import type {ShieldStyle} from "./ShieldStyle";
+import type {TextStyle} from "./TextStyle";
 
-import styleparser from "./Style";
+/**
+ * The styles that apply to one feature, keyed by subpart.
+ *
+ * The styles are plain copies rather than {@link Style} instances: a
+ * `StyleChooser` copies each matching style's own properties in, so that
+ * several declarations can be merged onto the same subpart.
+ */
+export type SubpartStyles<T> = Record<string, Partial<T>>;
 
-styleparser.StyleList = function () {
-  this.shapeStyles = {};
-  this.textStyles = {};
-  this.pointStyles = {};
-  this.shieldStyles = {};
-};
-styleparser.StyleList.prototype = {
-  maxwidth: 0,
-  subparts: [], // List of subparts used in this StyleList
-  validAt: -1, // Zoom level this is valid at (or -1 at all levels - saves recomputing)
+/** The result of matching a {@link RuleSet} against a single feature. */
+export class StyleList {
+  shapeStyles: SubpartStyles<ShapeStyle> = {};
+  textStyles: SubpartStyles<TextStyle> = {};
+  pointStyles: SubpartStyles<PointStyle> = {};
+  shieldStyles: SubpartStyles<ShieldStyle> = {};
 
-  hasStyles() {
-    // summary:		Does this StyleList contain any styles?
+  maxwidth = 0;
+  /** The subparts used in this StyleList. */
+  subparts: string[] = [];
+  /** Zoom level this is valid at, or -1 at all levels — saves recomputing. */
+  validAt = -1;
+
+  /** Does this StyleList contain any styles? */
+  hasStyles(): boolean {
     return (
       this.hasShapeStyles() ||
       this.hasTextStyles() ||
       this.hasPointStyles() ||
       this.hasShieldStyles()
     );
-  },
+  }
 
-  hasFills() {
-    // summary:		Does this StyleList contain any styles with a fill?
+  /** If this StyleList manually forces an OSM layer, return it. */
+  layerOverride(): number {
     for (const s in this.shapeStyles) {
-      if (
-        !isNaN(this.shapeStyles(s).fill_color) ||
-        this.shapeStyles(s).fill_image
-      )
-        return true;
-    }
-    return false;
-  },
-
-  layerOverride() {
-    // summary:		If this StyleList manually forces an OSM layer, return it, otherwise null.
-    for (const s in this.shapeStyles) {
-      if (!isNaN(this.shapeStyles[s].layer)) return this.shapeStyles[s].layer;
+      const layer = this.shapeStyles[s].layer;
+      if (!isNaN(layer)) return layer;
     }
     return NaN;
-  },
+  }
 
-  addSubpart(s) {
-    // summary:		Record that a subpart is used in this StyleList.
+  /** Records that a subpart is used in this StyleList. */
+  addSubpart(s: string): void {
     if (this.subparts.indexOf(s) == -1) {
       this.subparts.push(s);
     }
-  },
-
-  isValidAt(zoom) {
-    // summary:		Is this StyleList valid at a given zoom?
-    return this.validAt == -1 || this.validAt == zoom;
-  },
-
-  toString() {
-    // summary:		Summarise StyleList as String - for debugging
-    let str = "";
-    let k;
-    for (k in this.shapeStyles) {
-      str += `- SS ${k}=${this.shapeStyles[k]}\n`;
-    }
-    for (k in this.textStyles) {
-      str += `- TS ${k}=${this.textStyles[k]}\n`;
-    }
-    for (k in this.pointStyles) {
-      str += `- PS ${k}=${this.pointStyles[k]}\n`;
-    }
-    for (k in this.shieldStyles) {
-      str += `- sS ${k}=${this.shieldStyles[k]}\n`;
-    }
-    return str;
-  },
-
-  hasShapeStyles() {
-    for (const a in this.shapeStyles) {
-      return true;
-    }
-    return false;
-  },
-  hasTextStyles() {
-    for (const a in this.textStyles) {
-      return true;
-    }
-    return false;
-  },
-  hasPointStyles() {
-    for (const a in this.pointStyles) {
-      return true;
-    }
-    return false;
-  },
-  hasShieldStyles() {
-    for (const a in this.shieldStyles) {
-      return true;
-    }
-    return false;
   }
-};
+
+  isValidAt(zoom: number): boolean {
+    return this.validAt == -1 || this.validAt == zoom;
+  }
+
+  /** Summarises the StyleList as a string, for debugging. */
+  toString(): string {
+    const section = (label: string, styles: SubpartStyles<unknown>) =>
+      Object.entries(styles)
+        .map(([k, style]) => `- ${label} ${k}=${style}\n`)
+        .join("");
+    return (
+      section("SS", this.shapeStyles) +
+      section("TS", this.textStyles) +
+      section("PS", this.pointStyles) +
+      section("sS", this.shieldStyles)
+    );
+  }
+
+  hasShapeStyles(): boolean {
+    return Object.keys(this.shapeStyles).length > 0;
+  }
+
+  hasTextStyles(): boolean {
+    return Object.keys(this.textStyles).length > 0;
+  }
+
+  hasPointStyles(): boolean {
+    return Object.keys(this.pointStyles).length > 0;
+  }
+
+  hasShieldStyles(): boolean {
+    return Object.keys(this.shieldStyles).length > 0;
+  }
+}

--- a/js/jsmapcss/TextStyle.ts
+++ b/js/jsmapcss/TextStyle.ts
@@ -1,31 +1,59 @@
-import {Style, prototypeDefaults, styleString} from "./Style";
+import {Style, styleString} from "./Style";
 
 /** The label drawn for a feature, and the shield it may sit on. */
 export class TextStyle extends Style {
-  declare font_family: string | null;
-  declare font_size: string | null;
-  declare font_style: string | null;
-  declare font_variant: string | null;
-  declare font_weight: string | null;
-  declare max_width: string | null;
-  declare shield_casing_color: string | null;
-  declare shield_casing_width: string | null;
-  declare shield_color: string | null;
-  declare shield_frame_color: string | null;
-  declare shield_frame_width: string | null;
-  declare shield_image: string | null;
-  declare shield_opacity: string | null;
-  declare shield_shape: string | null;
-  declare shield_text: string | null;
-  declare text_color: string | null;
-  declare text_decoration: string | null;
-  declare text_halo_color: string | null;
-  declare text_halo_radius: number;
-  declare text_offset: string | null;
-  declare text_opacity: string | null;
-  declare text_position: string | null;
-  declare text_transform: string | null;
-  declare text: string | null;
+  override styleType = "TextStyle";
+  override properties = [
+    "font_family",
+    "font_size",
+    "font_style",
+    "font_variant",
+    "font_weight",
+    "max_width",
+    "shield_casing_color",
+    "shield_casing_width",
+    "shield_color",
+    "shield_frame_color",
+    "shield_frame_width",
+    "shield_image",
+    "shield_opacity",
+    "shield_shape",
+    "shield_text",
+    "text_color",
+    "text_decoration",
+    "text_halo_color",
+    "text_halo_radius",
+    "text_offset",
+    "text_opacity",
+    "text_position",
+    "text_transform",
+    "text"
+  ];
+
+  font_family: string | null = null;
+  font_size: string | null = null;
+  font_style: string | null = null;
+  font_variant: string | null = null;
+  font_weight: string | null = null;
+  max_width: string | null = null;
+  shield_casing_color: string | null = null;
+  shield_casing_width: string | null = null;
+  shield_color: string | null = null;
+  shield_frame_color: string | null = null;
+  shield_frame_width: string | null = null;
+  shield_image: string | null = null;
+  shield_opacity: string | null = null;
+  shield_shape: string | null = null;
+  shield_text: string | null = null;
+  text_color: string | null = null;
+  text_decoration: string | null = null;
+  text_halo_color: string | null = null;
+  text_halo_radius = 0;
+  text_offset: string | null = null;
+  text_opacity: string | null = null;
+  text_position: string | null = null;
+  text_transform: string | null = null;
+  text: string | null = null;
 
   /**
    * Renders this style as an inline CSS `style` attribute value.
@@ -57,57 +85,3 @@ export class TextStyle extends Style {
     });
   }
 }
-
-prototypeDefaults(TextStyle, {
-  styleType: "TextStyle",
-  properties: [
-    "font_family",
-    "font_size",
-    "font_style",
-    "font_variant",
-    "font_weight",
-    "max_width",
-    "shield_casing_color",
-    "shield_casing_width",
-    "shield_color",
-    "shield_frame_color",
-    "shield_frame_width",
-    "shield_image",
-    "shield_opacity",
-    "shield_shape",
-    "shield_text",
-    "text_color",
-    "text_decoration",
-    "text_halo_color",
-    "text_halo_radius",
-    "text_offset",
-    "text_opacity",
-    "text_position",
-    "text_transform",
-    "text"
-  ],
-  font_family: null,
-  font_size: null,
-  font_style: null,
-  font_variant: null,
-  font_weight: null,
-  max_width: null,
-  shield_casing_color: null,
-  shield_casing_width: null,
-  shield_color: null,
-  shield_frame_color: null,
-  shield_frame_width: null,
-  shield_image: null,
-  shield_opacity: null,
-  shield_shape: null,
-  shield_text: null,
-  text_color: null,
-  text_decoration: null,
-  text_halo_color: null,
-  text_halo_radius: 0,
-  text_offset: null,
-  text_opacity: null,
-  text_position: null,
-  text_transform: null,
-  text: null
-});

--- a/js/jsmapcss/TextStyle.ts
+++ b/js/jsmapcss/TextStyle.ts
@@ -1,0 +1,113 @@
+import {Style, prototypeDefaults, styleString} from "./Style";
+
+/** The label drawn for a feature, and the shield it may sit on. */
+export class TextStyle extends Style {
+  declare font_family: string | null;
+  declare font_size: string | null;
+  declare font_style: string | null;
+  declare font_variant: string | null;
+  declare font_weight: string | null;
+  declare max_width: string | null;
+  declare shield_casing_color: string | null;
+  declare shield_casing_width: string | null;
+  declare shield_color: string | null;
+  declare shield_frame_color: string | null;
+  declare shield_frame_width: string | null;
+  declare shield_image: string | null;
+  declare shield_opacity: string | null;
+  declare shield_shape: string | null;
+  declare shield_text: string | null;
+  declare text_color: string | null;
+  declare text_decoration: string | null;
+  declare text_halo_color: string | null;
+  declare text_halo_radius: number;
+  declare text_offset: string | null;
+  declare text_opacity: string | null;
+  declare text_position: string | null;
+  declare text_transform: string | null;
+  declare text: string | null;
+
+  /**
+   * Renders this style as an inline CSS `style` attribute value.
+   *
+   * Styles reach the map as plain objects copied out of a `StyleList`, so this
+   * is called with `Function.prototype.call` on something that is not
+   * necessarily a `TextStyle` instance.
+   */
+  textStyleAsCSS(this: Partial<TextStyle>): string {
+    return styleString({
+      borderColor: this.shield_frame_color,
+      borderStyle: this.shield_frame_color ? "solid" : null,
+      borderWidth: this.shield_frame_width,
+      backgroundColor: this.shield_color,
+      fontFamily: this.font_family,
+      fontSize: this.font_size,
+      fontStyle: this.font_style,
+      fontVariant: this.font_variant,
+      fontWeight: this.font_weight,
+      maxWidth: this.max_width,
+      color: this.text_color,
+      textDecoration: this.text_decoration,
+      textShadow:
+        this.text_halo_color && this.text_halo_radius > 0
+          ? `0 0 ${this.text_halo_radius}px ${this.text_halo_color}`
+          : null,
+      opacity: this.text_opacity,
+      transform: this.text_transform
+    });
+  }
+}
+
+prototypeDefaults(TextStyle, {
+  styleType: "TextStyle",
+  properties: [
+    "font_family",
+    "font_size",
+    "font_style",
+    "font_variant",
+    "font_weight",
+    "max_width",
+    "shield_casing_color",
+    "shield_casing_width",
+    "shield_color",
+    "shield_frame_color",
+    "shield_frame_width",
+    "shield_image",
+    "shield_opacity",
+    "shield_shape",
+    "shield_text",
+    "text_color",
+    "text_decoration",
+    "text_halo_color",
+    "text_halo_radius",
+    "text_offset",
+    "text_opacity",
+    "text_position",
+    "text_transform",
+    "text"
+  ],
+  font_family: null,
+  font_size: null,
+  font_style: null,
+  font_variant: null,
+  font_weight: null,
+  max_width: null,
+  shield_casing_color: null,
+  shield_casing_width: null,
+  shield_color: null,
+  shield_frame_color: null,
+  shield_frame_width: null,
+  shield_image: null,
+  shield_opacity: null,
+  shield_shape: null,
+  shield_text: null,
+  text_color: null,
+  text_decoration: null,
+  text_halo_color: null,
+  text_halo_radius: 0,
+  text_offset: null,
+  text_opacity: null,
+  text_position: null,
+  text_transform: null,
+  text: null
+});

--- a/js/jsmapcss/index.ts
+++ b/js/jsmapcss/index.ts
@@ -1,10 +1,14 @@
 /*! this is mostly based on work by Richard Fairhurst, initially developed for iD editor, but abbandoned. See: http://lists.openstreetmap.org/pipermail/mapcss/2013-February/000341.html . This is under WTFPL. */
-//export {default} from './eval.pegjs';
-export {default} from "./Style";
-import "./Condition";
-import "./Rule";
-import "./RuleChain";
-import "./RuleSet";
-import "./Style";
-import "./StyleChooser";
-import "./StyleList";
+
+export {Condition, type ConditionType} from "./Condition";
+export {InstructionStyle} from "./InstructionStyle";
+export {PointStyle} from "./PointStyle";
+export {type Entity, Rule} from "./Rule";
+export {RuleChain} from "./RuleChain";
+export {RuleSet} from "./RuleSet";
+export {ShapeStyle} from "./ShapeStyle";
+export {ShieldStyle} from "./ShieldStyle";
+export {Style, type StyleValue, type Tags, styleString} from "./Style";
+export {StyleChooser} from "./StyleChooser";
+export {StyleList, type SubpartStyles} from "./StyleList";
+export {TextStyle} from "./TextStyle";

--- a/js/leaflet.polylineoffset.ts
+++ b/js/leaflet.polylineoffset.ts
@@ -3,7 +3,7 @@
  * @license MIT
  * @see github.com/bbecquet/Leaflet.PolylineOffset
  */
-import "leaflet";
+import * as L from "leaflet";
 
 function forEachPair(list, callback) {
   if (!list || list.length < 1) {

--- a/js/map.ts
+++ b/js/map.ts
@@ -110,7 +110,6 @@ $(document).ready(() => {
       $("#map_blank").remove();
     }
   };
-  overpass.init();
   // (very raw) compatibility check
   if (typeof fetch !== "function") {
     // the currently used browser is not capable of running the IDE. :(

--- a/js/map.ts
+++ b/js/map.ts
@@ -1,6 +1,6 @@
 // escape strings to show them directly in the html.
 import $ from "jquery";
-import "leaflet";
+import * as L from "leaflet";
 
 // include the CSS files
 import "leaflet/dist/leaflet.css";

--- a/js/map.ts
+++ b/js/map.ts
@@ -10,6 +10,19 @@ import overpass from "./overpass";
 import Query from "./query";
 import {parseUrlParameters} from "./urlParameters";
 
+declare global {
+  interface JQuery {
+    /** jquery-ui's dialog, which map.html does not load — stubbed below */
+    dialog(options?: Record<string, unknown>): void;
+  }
+}
+
+/** the `[data:…]` statement of a query, naming a non-Overpass data source */
+interface DataSource {
+  mode: string;
+  options: Record<string, string>;
+}
+
 $(document).ready(() => {
   // main map cache
   const cache = {};
@@ -55,6 +68,7 @@ $(document).ready(() => {
   const ide = {
     map: undefined as unknown as L.Map,
     mapcss: "",
+    data_source: null as DataSource | null,
     async getQuery(): Promise<string> {
       let query = settings.code["overpass"];
       const queryParser = new Query();
@@ -145,7 +159,7 @@ $(document).ready(() => {
   });
   ide.map.on("layeradd", (e) => {
     if (!(e.layer instanceof L.GeoJSON)) return;
-    ide.map.setView([0, 0], 18, true);
+    ide.map.setView([0, 0], 18);
     try {
       ide.map.fitBounds(e.layer.getBounds());
     } catch {}

--- a/js/misc.ts
+++ b/js/misc.ts
@@ -15,7 +15,7 @@ export const Base64 = {
   _keyStr: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=",
 
   // public method for encoding
-  encode(input, not_base64url) {
+  encode(input: string, not_base64url?: boolean) {
     let output = "";
     //input = Base64._utf8_encode(input);
     input = unescape(encodeURIComponent(input));

--- a/js/misc.ts
+++ b/js/misc.ts
@@ -57,7 +57,7 @@ export const Base64 = {
 
   // public method for decoding
   // this decodes base64url as well as standard base64 with or without padding)
-  decode(input, binary) {
+  decode(input: string) {
     let output = "";
     input = this._convert_to_base64nopad(input);
     input = input.replace(/[^A-Za-z0-9+/]/g, "");
@@ -92,28 +92,14 @@ export const Base64 = {
       }
     }
 
-    function str2ab(str) {
-      const buf = new ArrayBuffer(str.length); // 1 byte for each char
-      const bufView = new Uint8Array(buf);
-      for (let i = 0, strLen = str.length; i < strLen; i++) {
-        bufView[i] = str.charCodeAt(i);
-      }
-      return buf;
-    }
-
-    if (!binary) {
-      // try to decode utf8 characters
-      try {
-        output = decodeURIComponent(escape(output));
-      } catch {}
-    } else {
-      // convert binary string to typed (Uint8) array
-      output = str2ab(output);
-    }
+    // try to decode utf8 characters
+    try {
+      output = decodeURIComponent(escape(output));
+    } catch {}
     return output;
   },
 
-  encodeNum(num, not_base64url) {
+  encodeNum(num: number, not_base64url?: boolean) {
     let output = "";
     if (num == 0) return this._keyStr.charAt(0);
     let neg = false;

--- a/js/overpass.ts
+++ b/js/overpass.ts
@@ -398,7 +398,10 @@ class Overpass {
                 }
               } catch (e) {
                 userMapCSS = "";
-                overpass.fire("onStyleError", `<p>${e.message}</p>`);
+                overpass.fire(
+                  "onStyleError",
+                  `<p>${e instanceof Error ? e.message : e}</p>`
+                );
               }
               const mapcss = new RuleSet();
               mapcss.parseCSS(

--- a/js/overpass.ts
+++ b/js/overpass.ts
@@ -6,7 +6,7 @@ import configs from "./configs";
 import L_GeoJsonNoVanish from "./GeoJsonNoVanish";
 import {HttpError, request} from "./httpRequest";
 import ide from "./ide";
-import styleparser from "./jsmapcss";
+import {RuleSet, TextStyle} from "./jsmapcss";
 import {htmlentities} from "./misc";
 import L_OSM4Leaflet from "./OSM4Leaflet";
 import {featurePopupContent} from "./popup";
@@ -88,30 +88,6 @@ class Overpass {
   private fire(name, ...handler_args) {
     if (typeof this.handlers[name] != "function") return undefined;
     return this.handlers[name].apply({}, handler_args);
-  }
-
-  init() {
-    // register mapcss extensions
-    /* own MapCSS-extension:
-     * added symbol-* properties
-     * TODO: implement symbol-shape = marker|square?|shield?|...
-     */
-    styleparser.PointStyle.prototype.properties.push(
-      "symbol_shape",
-      "symbol_size",
-      "symbol_stroke_width",
-      "symbol_stroke_color",
-      "symbol_stroke_opacity",
-      "symbol_fill_color",
-      "symbol_fill_opacity"
-    );
-    styleparser.PointStyle.prototype.symbol_shape = "";
-    styleparser.PointStyle.prototype.symbol_size = NaN;
-    styleparser.PointStyle.prototype.symbol_stroke_width = NaN;
-    styleparser.PointStyle.prototype.symbol_stroke_color = null;
-    styleparser.PointStyle.prototype.symbol_stroke_opacity = NaN;
-    styleparser.PointStyle.prototype.symbol_fill_color = null;
-    styleparser.PointStyle.prototype.symbol_fill_opacity = NaN;
   }
 
   // updates the map
@@ -385,7 +361,7 @@ class Overpass {
             overpass.rerender = function (userMapCSS) {
               // test user supplied mapcss stylesheet
               try {
-                const dummy_mapcss = new styleparser.RuleSet();
+                const dummy_mapcss = new RuleSet();
                 dummy_mapcss.parseCSS(userMapCSS);
                 try {
                   dummy_mapcss.getStyles(
@@ -407,7 +383,7 @@ class Overpass {
                 userMapCSS = "";
                 overpass.fire("onStyleError", `<p>${e.message}</p>`);
               }
-              const mapcss = new styleparser.RuleSet();
+              const mapcss = new RuleSet();
               mapcss.parseCSS(
                 `` +
                   `node, way, relation {color:black; fill-color:black; opacity:1; fill-opacity: 1; width:10;} \n` +
@@ -676,9 +652,7 @@ class Overpass {
                         L.Tooltip.prototype._initLayout.call(this);
                         this._container.setAttribute(
                           "style",
-                          styleparser.TextStyle.prototype.textStyleAsCSS.call(
-                            stl
-                          )
+                          TextStyle.prototype.textStyleAsCSS.call(stl)
                         );
                       };
                       layer.bindTooltip(tooltip);

--- a/js/overpass.ts
+++ b/js/overpass.ts
@@ -3,7 +3,7 @@ import $ from "jquery";
 import * as L from "leaflet";
 
 import configs from "./configs";
-import L_GeoJsonNoVanish from "./GeoJsonNoVanish";
+import L_GeoJsonNoVanish, {type RenderMode} from "./GeoJsonNoVanish";
 import {HttpError, request} from "./httpRequest";
 import ide from "./ide";
 import {RuleSet, TextStyle} from "./jsmapcss";
@@ -14,6 +14,23 @@ import L_PopupIcon from "./PopupIcon"; // eslint-disable-line @typescript-eslint
 import settings from "./settings";
 
 export type QueryLang = "xml" | "OverpassQL" | "SQL";
+
+/** Leaflet's path options, plus overpass turbo's own MapCSS `render` property. */
+interface FeatureStyle extends L.PathOptions {
+  render?: RenderMode;
+}
+
+declare module "leaflet" {
+  interface Popup {
+    /** the layer this popup was opened for */
+    layer?: Layer;
+  }
+  interface Tooltip {
+    /** internal; overridden below to apply a MapCSS text style to the tooltip */
+    _initLayout(): void;
+    _container: HTMLElement;
+  }
+}
 
 /** an Overpass API (or SQL server) response, parsed according to its content type */
 interface QueryResponse {
@@ -245,7 +262,7 @@ class Overpass {
                 for (const errline of errlines) {
                   overpass.fire(
                     "onQueryErrorLine",
-                    1 * errline.match(/\d+/)[0]
+                    Number(errline.match(/\d+/)[0])
                   );
                 }
               }
@@ -373,7 +390,7 @@ class Overpass {
                         return [];
                       }
                     },
-                    [],
+                    {},
                     18
                   );
                 } catch {
@@ -503,7 +520,6 @@ class Overpass {
                   overpass.fire("onProgress", "rendering geoJSON");
                 },
                 baseLayerClass: L_GeoJsonNoVanish,
-                query_lang: query_lang,
                 baseLayerOptions: {
                   threshold: 9 * Math.sqrt(2) * 2,
                   compress(feature) {
@@ -513,7 +529,7 @@ class Overpass {
                     else return render;
                   },
                   style(feature, highlight) {
-                    const stl: L.PathOptions = {};
+                    const stl: FeatureStyle = {};
                     const s = get_feature_style(feature, highlight);
                     // apply mapcss styles
                     function get_property(styles, properties) {
@@ -643,7 +659,7 @@ class Overpass {
                       (text && (text = feature.properties.tags[text]))
                     ) {
                       const tooltip = new L.Tooltip({
-                        direction: stl["text_position"],
+                        direction: stl.text_position as L.Direction,
                         className: "text-tooltip",
                         permanent: true
                       });

--- a/js/overpass.ts
+++ b/js/overpass.ts
@@ -1,6 +1,6 @@
 // global overpass object
 import $ from "jquery";
-import "leaflet";
+import * as L from "leaflet";
 
 import configs from "./configs";
 import L_GeoJsonNoVanish from "./GeoJsonNoVanish";

--- a/js/pegjs.d.ts
+++ b/js/pegjs.d.ts
@@ -1,0 +1,11 @@
+/**
+ * Grammars are compiled to a parser module by the `peggy` plugin in
+ * vite.config.mts, so they are importable but have no declarations of their own.
+ */
+declare module "*.pegjs" {
+  const parser: {
+    parse(input: string, options?: Record<string, unknown>): unknown;
+    SyntaxError: new (...args: unknown[]) => Error;
+  };
+  export default parser;
+}

--- a/js/settings.ts
+++ b/js/settings.ts
@@ -1,6 +1,12 @@
 // Settings class
 import configs from "./configs";
 
+/**
+ * A value a setting can hold. Anything but a `String` setting is stored as
+ * JSON, so any serialisable value will do.
+ */
+type SettingValue = string | number | boolean | string[] | object;
+
 class Settings {
   // settings.define_setting
   coords_lat: number;
@@ -36,7 +42,7 @@ class Settings {
     string,
     {
       type: string;
-      preset: string | number | boolean | string[];
+      preset: SettingValue;
       version: number;
     }
   >;
@@ -58,7 +64,7 @@ class Settings {
   define_setting(
     name: string,
     type: string,
-    preset: string | number | boolean | string[],
+    preset: SettingValue,
     version: number
   ) {
     this.settings[name] = {type: type, preset: preset, version: version};
@@ -67,16 +73,18 @@ class Settings {
     this.upgrade_callbacks[version] = fun;
   }
 
-  set(name: string, value: string) {
+  set(name: string, value?: SettingValue) {
     if (
       value === undefined // use preset if no value is given
     )
       value = this.settings[name].preset;
-    if (this.settings[name].type != "String") {
+    localStorage.setItem(
+      this.prefix + name,
       // stringify all non-string values.
-      value = JSON.stringify(value);
-    }
-    localStorage.setItem(this.prefix + name, value);
+      this.settings[name].type == "String"
+        ? String(value)
+        : JSON.stringify(value)
+    );
   }
   get(name: string) {
     // initialize new settings
@@ -103,7 +111,7 @@ class Settings {
           this.upgrade_callbacks[v](this);
       }
       this.version = this.settings_version;
-      localStorage.setItem(`${this.prefix}version`, this.version);
+      localStorage.setItem(`${this.prefix}version`, String(this.version));
     }
   }
   save() {

--- a/js/sync-with-osm.ts
+++ b/js/sync-with-osm.ts
@@ -1,4 +1,4 @@
-import {osmAuth} from "osm-auth";
+import {type OSMAuthFetchOptions, osmAuth} from "osm-auth";
 
 import configs from "./configs";
 import {HttpError} from "./httpRequest";
@@ -18,13 +18,17 @@ interface QueryUpdate {
 
 const enabled = configs.osmAuth && configs.osmAuth.client_id;
 
-if (!configs.osmAuth.redirect_uri) {
-  configs.osmAuth.redirect_uri = `${window.location.origin}${window.location.pathname}land.html`;
-}
-configs.osmAuth.scope = "read_prefs write_prefs";
-
-let auth;
-if (enabled) auth = osmAuth(configs.osmAuth);
+const auth = enabled
+  ? new osmAuth({
+      ...configs.osmAuth,
+      client_id: configs.osmAuth.client_id,
+      // land.html completes the OAuth redirect
+      redirect_uri:
+        configs.osmAuth.redirect_uri ||
+        `${window.location.origin}${window.location.pathname}land.html`,
+      scope: "read_prefs write_prefs"
+    })
+  : undefined;
 
 const preferencesPath = "/api/0.6/user/preferences";
 
@@ -41,7 +45,7 @@ function authenticate(): Promise<void> {
  */
 async function apiRequest(
   path: string,
-  options: RequestInit
+  options: OSMAuthFetchOptions
 ): Promise<Response> {
   const res: Response = await auth.fetch(auth.options().apiUrl + path, options);
   if (!res.ok) throw new HttpError(res, await res.text().catch(() => ""));

--- a/js/vite-env.d.ts
+++ b/js/vite-env.d.ts
@@ -1,0 +1,13 @@
+/// <reference types="vite/client" />
+
+/** Values vite.config.mts puts into process.env for vite to expose here. */
+interface ImportMetaEnv {
+  /** The date and `git describe` of the commit the app was built from. */
+  readonly VITE_GIT_VERSION: string;
+  /** The app's dependencies and their licences, as an HTML fragment. */
+  readonly VITE_APP_DEPENDENCIES: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@types/leaflet": "^1.9.3",
     "happy-dom": "^20.10.6",
     "peggy": "^3.0.2",
-    "typescript": "^5.0.4",
+    "typescript": "^6.0.3",
     "vite": "catalog:",
     "vite-plus": "catalog:"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,14 +100,14 @@ importers:
         specifier: ^3.0.2
         version: 3.0.2
       typescript:
-        specifier: ^5.0.4
-        version: 5.1.6
+        specifier: ^6.0.3
+        version: 6.0.3
       vite:
         specifier: npm:@voidzero-dev/vite-plus-core@0.2.4
-        version: '@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.1)(typescript@5.1.6)(yaml@2.4.5)'
+        version: '@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.1)(typescript@6.0.3)(yaml@2.4.5)'
       vite-plus:
         specifier: 'catalog:'
-        version: 0.2.4(@types/node@26.1.1)(@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.1)(typescript@5.1.6)(yaml@2.4.5))(happy-dom@20.10.6)(typescript@5.1.6)(yaml@2.4.5)
+        version: 0.2.4(@types/node@26.1.1)(@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.1)(typescript@6.0.3)(yaml@2.4.5))(happy-dom@20.10.6)(typescript@6.0.3)(yaml@2.4.5)
 
 packages:
 
@@ -1212,8 +1212,8 @@ packages:
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
-  typescript@5.1.6:
-    resolution: {integrity: sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -1549,28 +1549,28 @@ snapshots:
     dependencies:
       '@types/node': 26.1.1
 
-  '@vitest/browser-preview@4.1.10(@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.1)(typescript@5.1.6)(yaml@2.4.5))(vitest@4.1.10)':
+  '@vitest/browser-preview@4.1.10(@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.1)(typescript@6.0.3)(yaml@2.4.5))(vitest@4.1.10)':
     dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
-      '@vitest/browser': 4.1.10(@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.1)(typescript@5.1.6)(yaml@2.4.5))(vitest@4.1.10)
-      vitest: 4.1.10(@types/node@26.1.1)(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.1)(typescript@5.1.6)(yaml@2.4.5))(happy-dom@20.10.6)
+      '@vitest/browser': 4.1.10(@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.1)(typescript@6.0.3)(yaml@2.4.5))(vitest@4.1.10)
+      vitest: 4.1.10(@types/node@26.1.1)(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.1)(typescript@6.0.3)(yaml@2.4.5))(happy-dom@20.10.6)
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.10(@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.1)(typescript@5.1.6)(yaml@2.4.5))(vitest@4.1.10)':
+  '@vitest/browser@4.1.10(@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.1)(typescript@6.0.3)(yaml@2.4.5))(vitest@4.1.10)':
     dependencies:
       '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.10(@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.1)(typescript@5.1.6)(yaml@2.4.5))
+      '@vitest/mocker': 4.1.10(@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.1)(typescript@6.0.3)(yaml@2.4.5))
       '@vitest/utils': 4.1.10
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@26.1.1)(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.1)(typescript@5.1.6)(yaml@2.4.5))(happy-dom@20.10.6)
+      vitest: 4.1.10(@types/node@26.1.1)(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.1)(typescript@6.0.3)(yaml@2.4.5))(happy-dom@20.10.6)
       ws: 8.21.1
     transitivePeerDependencies:
       - bufferutil
@@ -1587,13 +1587,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.10(@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.1)(typescript@5.1.6)(yaml@2.4.5))':
+  '@vitest/mocker@4.1.10(@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.1)(typescript@6.0.3)(yaml@2.4.5))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: '@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.1)(typescript@5.1.6)(yaml@2.4.5)'
+      vite: '@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.1)(typescript@6.0.3)(yaml@2.4.5)'
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
@@ -1619,7 +1619,7 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.1)(typescript@5.1.6)(yaml@2.4.5)':
+  '@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.1)(typescript@6.0.3)(yaml@2.4.5)':
     dependencies:
       '@oxc-project/runtime': 0.138.0
       '@oxc-project/types': 0.138.0
@@ -1628,7 +1628,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 26.1.1
       fsevents: 2.3.3
-      typescript: 5.1.6
+      typescript: 6.0.3
       yaml: 2.4.5
 
   '@voidzero-dev/vite-plus-darwin-arm64@0.2.4':
@@ -1961,7 +1961,7 @@ snapshots:
     optionalDependencies:
       '@types/geojson': 7946.0.10
 
-  oxfmt@0.57.0(vite-plus@0.2.4(@types/node@26.1.1)(@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.1)(typescript@5.1.6)(yaml@2.4.5))(happy-dom@20.10.6)(typescript@5.1.6)(yaml@2.4.5)):
+  oxfmt@0.57.0(vite-plus@0.2.4(@types/node@26.1.1)(@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.1)(typescript@6.0.3)(yaml@2.4.5))(happy-dom@20.10.6)(typescript@6.0.3)(yaml@2.4.5)):
     dependencies:
       tinypool: 2.1.0
     optionalDependencies:
@@ -1984,7 +1984,7 @@ snapshots:
       '@oxfmt/binding-win32-arm64-msvc': 0.57.0
       '@oxfmt/binding-win32-ia32-msvc': 0.57.0
       '@oxfmt/binding-win32-x64-msvc': 0.57.0
-      vite-plus: 0.2.4(@types/node@26.1.1)(@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.1)(typescript@5.1.6)(yaml@2.4.5))(happy-dom@20.10.6)(typescript@5.1.6)(yaml@2.4.5)
+      vite-plus: 0.2.4(@types/node@26.1.1)(@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.1)(typescript@6.0.3)(yaml@2.4.5))(happy-dom@20.10.6)(typescript@6.0.3)(yaml@2.4.5)
 
   oxlint-tsgolint@0.24.0:
     optionalDependencies:
@@ -1995,7 +1995,7 @@ snapshots:
       '@oxlint-tsgolint/win32-arm64': 0.24.0
       '@oxlint-tsgolint/win32-x64': 0.24.0
 
-  oxlint@1.72.0(oxlint-tsgolint@0.24.0)(vite-plus@0.2.4(@types/node@26.1.1)(@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.1)(typescript@5.1.6)(yaml@2.4.5))(happy-dom@20.10.6)(typescript@5.1.6)(yaml@2.4.5)):
+  oxlint@1.72.0(oxlint-tsgolint@0.24.0)(vite-plus@0.2.4(@types/node@26.1.1)(@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.1)(typescript@6.0.3)(yaml@2.4.5))(happy-dom@20.10.6)(typescript@6.0.3)(yaml@2.4.5)):
     optionalDependencies:
       '@oxlint/binding-android-arm-eabi': 1.72.0
       '@oxlint/binding-android-arm64': 1.72.0
@@ -2017,7 +2017,7 @@ snapshots:
       '@oxlint/binding-win32-ia32-msvc': 1.72.0
       '@oxlint/binding-win32-x64-msvc': 1.72.0
       oxlint-tsgolint: 0.24.0
-      vite-plus: 0.2.4(@types/node@26.1.1)(@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.1)(typescript@5.1.6)(yaml@2.4.5))(happy-dom@20.10.6)(typescript@5.1.6)(yaml@2.4.5)
+      vite-plus: 0.2.4(@types/node@26.1.1)(@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.1)(typescript@6.0.3)(yaml@2.4.5))(happy-dom@20.10.6)(typescript@6.0.3)(yaml@2.4.5)
 
   pathe@2.0.3: {}
 
@@ -2188,7 +2188,7 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typescript@5.1.6: {}
+  typescript@6.0.3: {}
 
   uglify-js@1.1.1: {}
 
@@ -2200,24 +2200,24 @@ snapshots:
     dependencies:
       base64-arraybuffer: 1.0.2
 
-  vite-plus@0.2.4(@types/node@26.1.1)(@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.1)(typescript@5.1.6)(yaml@2.4.5))(happy-dom@20.10.6)(typescript@5.1.6)(yaml@2.4.5):
+  vite-plus@0.2.4(@types/node@26.1.1)(@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.1)(typescript@6.0.3)(yaml@2.4.5))(happy-dom@20.10.6)(typescript@6.0.3)(yaml@2.4.5):
     dependencies:
       '@oxc-project/types': 0.138.0
       '@oxlint/plugins': 1.68.0
-      '@vitest/browser': 4.1.10(@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.1)(typescript@5.1.6)(yaml@2.4.5))(vitest@4.1.10)
-      '@vitest/browser-preview': 4.1.10(@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.1)(typescript@5.1.6)(yaml@2.4.5))(vitest@4.1.10)
+      '@vitest/browser': 4.1.10(@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.1)(typescript@6.0.3)(yaml@2.4.5))(vitest@4.1.10)
+      '@vitest/browser-preview': 4.1.10(@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.1)(typescript@6.0.3)(yaml@2.4.5))(vitest@4.1.10)
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.1)(typescript@5.1.6)(yaml@2.4.5))
+      '@vitest/mocker': 4.1.10(@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.1)(typescript@6.0.3)(yaml@2.4.5))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
       '@vitest/spy': 4.1.10
       '@vitest/utils': 4.1.10
-      '@voidzero-dev/vite-plus-core': 0.2.4(@types/node@26.1.1)(typescript@5.1.6)(yaml@2.4.5)
-      oxfmt: 0.57.0(vite-plus@0.2.4(@types/node@26.1.1)(@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.1)(typescript@5.1.6)(yaml@2.4.5))(happy-dom@20.10.6)(typescript@5.1.6)(yaml@2.4.5))
-      oxlint: 1.72.0(oxlint-tsgolint@0.24.0)(vite-plus@0.2.4(@types/node@26.1.1)(@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.1)(typescript@5.1.6)(yaml@2.4.5))(happy-dom@20.10.6)(typescript@5.1.6)(yaml@2.4.5))
+      '@voidzero-dev/vite-plus-core': 0.2.4(@types/node@26.1.1)(typescript@6.0.3)(yaml@2.4.5)
+      oxfmt: 0.57.0(vite-plus@0.2.4(@types/node@26.1.1)(@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.1)(typescript@6.0.3)(yaml@2.4.5))(happy-dom@20.10.6)(typescript@6.0.3)(yaml@2.4.5))
+      oxlint: 1.72.0(oxlint-tsgolint@0.24.0)(vite-plus@0.2.4(@types/node@26.1.1)(@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.1)(typescript@6.0.3)(yaml@2.4.5))(happy-dom@20.10.6)(typescript@6.0.3)(yaml@2.4.5))
       oxlint-tsgolint: 0.24.0
-      vitest: 4.1.10(@types/node@26.1.1)(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.1)(typescript@5.1.6)(yaml@2.4.5))(happy-dom@20.10.6)
+      vitest: 4.1.10(@types/node@26.1.1)(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.1)(typescript@6.0.3)(yaml@2.4.5))(happy-dom@20.10.6)
     optionalDependencies:
       '@voidzero-dev/vite-plus-darwin-arm64': 0.2.4
       '@voidzero-dev/vite-plus-darwin-x64': 0.2.4
@@ -2258,10 +2258,10 @@ snapshots:
       - vite
       - yaml
 
-  vitest@4.1.10(@types/node@26.1.1)(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.1)(typescript@5.1.6)(yaml@2.4.5))(happy-dom@20.10.6):
+  vitest@4.1.10(@types/node@26.1.1)(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.1)(typescript@6.0.3)(yaml@2.4.5))(happy-dom@20.10.6):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.1)(typescript@5.1.6)(yaml@2.4.5))
+      '@vitest/mocker': 4.1.10(@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.1)(typescript@6.0.3)(yaml@2.4.5))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -2278,11 +2278,11 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: '@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.1)(typescript@5.1.6)(yaml@2.4.5)'
+      vite: '@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.1)(typescript@6.0.3)(yaml@2.4.5)'
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 26.1.1
-      '@vitest/browser-preview': 4.1.10(@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.1)(typescript@5.1.6)(yaml@2.4.5))(vitest@4.1.10)
+      '@vitest/browser-preview': 4.1.10(@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.1)(typescript@6.0.3)(yaml@2.4.5))(vitest@4.1.10)
       happy-dom: 20.10.6
     transitivePeerDependencies:
       - msw

--- a/tests/test.ffs.ts
+++ b/tests/test.ffs.ts
@@ -456,7 +456,7 @@ describe("ide.ffs", () => {
 
     it("preset not found", async () => {
       const search = "foo";
-      await expect(construct_query(search)).rejects.to.throw(
+      await expect(construct_query(search)).rejects.toThrow(
         "unknown ffs string"
       );
     });

--- a/tests/test.mapcss.ts
+++ b/tests/test.mapcss.ts
@@ -1,9 +1,9 @@
 import {describe, expect, it} from "vite-plus/test";
 
-import styleparser from "../js/jsmapcss";
+import {type Entity, RuleSet, TextStyle} from "../js/jsmapcss";
 
 /** A minimal stand-in for the entity interface RuleChain.test() expects. */
-function entity(type: string, parents: unknown[] = []) {
+function entity(type: string, parents: Entity[] = []): Entity {
   return {
     isSubject: (subject: string) => subject === type,
     getParentObjects: () => parents
@@ -11,7 +11,7 @@ function entity(type: string, parents: unknown[] = []) {
 }
 
 function styles(css: string, type: string, tags: Record<string, string>) {
-  const ruleset = new styleparser.RuleSet();
+  const ruleset = new RuleSet();
   ruleset.parseCSS(css);
   return ruleset.getStyles(entity(type), tags, 18);
 }
@@ -56,6 +56,17 @@ describe("MapCSS styles", () => {
     ]);
   });
 
+  // The style must not inherit the defaults either: consumers treat a property
+  // as absent when reading it yields undefined, so an inherited `width: 0`
+  // would be applied as though the stylesheet had asked for it.
+  it("does not inherit the defaults of its style type", () => {
+    const sl = styles("way {color: #ff0000;}", "way", {});
+    expect(sl.shapeStyles.default.width).toBeUndefined();
+    expect(Object.getPrototypeOf(sl.shapeStyles.default)).toBe(
+      Object.prototype
+    );
+  });
+
   it("merges later rules into earlier ones without dropping their properties", () => {
     const sl = styles(
       "way {color: #ff0000; width: 3;} way[bridge=yes] {width: 7;}",
@@ -84,7 +95,7 @@ describe("MapCSS styles", () => {
   });
 
   it("honours zoom ranges", () => {
-    const ruleset = new styleparser.RuleSet();
+    const ruleset = new RuleSet();
     ruleset.parseCSS("way|z10-12 {color: #ff0000;}");
     expect(
       ruleset.getStyles(entity("way"), {}, 11).shapeStyles.default
@@ -95,7 +106,7 @@ describe("MapCSS styles", () => {
   });
 
   it("parses named and hex CSS colours", () => {
-    const ruleset = new styleparser.RuleSet();
+    const ruleset = new RuleSet();
     expect(ruleset.parseCSSColor("red")).toBe(0xff0000);
     expect(ruleset.parseCSSColor("#abc")).toBe(0xaabbcc);
     expect(ruleset.parseCSSColor("#a1b2c3")).toBe(0xa1b2c3);
@@ -103,14 +114,12 @@ describe("MapCSS styles", () => {
 
   it("renders a text style as inline CSS", () => {
     const sl = styles("node {text: name; text-color: #123456;}", "node", {});
-    const css = styleparser.TextStyle.prototype.textStyleAsCSS.call(
-      sl.textStyles.default
-    );
+    const css = TextStyle.prototype.textStyleAsCSS.call(sl.textStyles.default);
     expect(css).toContain("color: #123456");
   });
 
   it("rejects malformed MapCSS", () => {
-    const ruleset = new styleparser.RuleSet();
+    const ruleset = new RuleSet();
     expect(() => ruleset.parseCSS("way {color: #f00;} $$$")).toThrow();
   });
 });

--- a/tests/test.mapcss.ts
+++ b/tests/test.mapcss.ts
@@ -1,0 +1,116 @@
+import {describe, expect, it} from "vite-plus/test";
+
+import styleparser from "../js/jsmapcss";
+
+/** A minimal stand-in for the entity interface RuleChain.test() expects. */
+function entity(type: string, parents: unknown[] = []) {
+  return {
+    isSubject: (subject: string) => subject === type,
+    getParentObjects: () => parents
+  };
+}
+
+function styles(css: string, type: string, tags: Record<string, string>) {
+  const ruleset = new styleparser.RuleSet();
+  ruleset.parseCSS(css);
+  return ruleset.getStyles(entity(type), tags, 18);
+}
+
+describe("MapCSS styles", () => {
+  it("applies a declaration to a matching selector", () => {
+    const sl = styles("way {color: #ff0000; width: 3;}", "way", {
+      highway: "primary"
+    });
+    expect(sl.shapeStyles.default.color).toBe("#ff0000");
+    expect(sl.shapeStyles.default.width).toBe(3);
+  });
+
+  it("skips a declaration whose condition does not match", () => {
+    const sl = styles("way[highway=primary] {color: #ff0000;}", "way", {
+      highway: "residential"
+    });
+    expect(sl.shapeStyles.default).toBeUndefined();
+  });
+
+  it("sorts properties into the style subtype that owns them", () => {
+    const sl = styles(
+      "node {icon-image: url(foo.png); text: name; color: #00ff00;}",
+      "node",
+      {}
+    );
+    expect(sl.pointStyles.default.icon_image).toBe("url(foo.png)");
+    expect(sl.textStyles.default.text).toBe("name");
+    expect(sl.shapeStyles.default.color).toBe("#00ff00");
+  });
+
+  // Style defaults live on the prototype, and StyleChooser copies only own
+  // properties into the StyleList. A style therefore carries *only* the
+  // properties its declaration actually set — which is what keeps the merge
+  // below from clobbering earlier rules with later rules' defaults.
+  it("carries only explicitly set properties", () => {
+    const sl = styles("way {color: #ff0000;}", "way", {});
+    expect(Object.keys(sl.shapeStyles.default).sort()).toEqual([
+      "color",
+      "edited",
+      "evals"
+    ]);
+  });
+
+  it("merges later rules into earlier ones without dropping their properties", () => {
+    const sl = styles(
+      "way {color: #ff0000; width: 3;} way[bridge=yes] {width: 7;}",
+      "way",
+      {bridge: "yes"}
+    );
+    // width comes from the second rule, color survives from the first
+    expect(sl.shapeStyles.default.width).toBe(7);
+    expect(sl.shapeStyles.default.color).toBe("#ff0000");
+  });
+
+  it("evaluates eval() properties against the feature's tags", () => {
+    const sl = styles("way {width: eval(\"tag('lanes')\");}", "way", {
+      lanes: "4"
+    });
+    expect(sl.shapeStyles.default.width).toBe(4);
+  });
+
+  it("applies set-tag instructions before evaluating later rules", () => {
+    const sl = styles(
+      "way[highway] {set .road;} way.road {color: #0000ff;}",
+      "way",
+      {highway: "primary"}
+    );
+    expect(sl.shapeStyles.default.color).toBe("#0000ff");
+  });
+
+  it("honours zoom ranges", () => {
+    const ruleset = new styleparser.RuleSet();
+    ruleset.parseCSS("way|z10-12 {color: #ff0000;}");
+    expect(
+      ruleset.getStyles(entity("way"), {}, 11).shapeStyles.default
+    ).toBeDefined();
+    expect(
+      ruleset.getStyles(entity("way"), {}, 15).shapeStyles.default
+    ).toBeUndefined();
+  });
+
+  it("parses named and hex CSS colours", () => {
+    const ruleset = new styleparser.RuleSet();
+    expect(ruleset.parseCSSColor("red")).toBe(0xff0000);
+    expect(ruleset.parseCSSColor("#abc")).toBe(0xaabbcc);
+    expect(ruleset.parseCSSColor("#a1b2c3")).toBe(0xa1b2c3);
+  });
+
+  it("renders a text style as inline CSS", () => {
+    const sl = styles("node {text: name; text-color: #123456;}", "node", {});
+    const css = styleparser.TextStyle.prototype.textStyleAsCSS.call(
+      sl.textStyles.default
+    );
+    expect(css).toContain("color: #123456");
+  });
+
+  it("rejects malformed MapCSS", () => {
+    const ruleset = new styleparser.RuleSet();
+    expect(() => ruleset.parseCSS("way {color: #f00;} $$$")).toThrow();
+  });
+});

--- a/tests/test.mapcss.ts
+++ b/tests/test.mapcss.ts
@@ -43,15 +43,13 @@ describe("MapCSS styles", () => {
     expect(sl.shapeStyles.default.color).toBe("#00ff00");
   });
 
-  // Style defaults live on the prototype, and StyleChooser copies only own
-  // properties into the StyleList. A style therefore carries *only* the
-  // properties its declaration actually set — which is what keeps the merge
-  // below from clobbering earlier rules with later rules' defaults.
+  // A style contributes only the properties its declaration assigned, which is
+  // what keeps the merge below from clobbering earlier rules with the defaults
+  // of later ones. `evals` always comes along.
   it("carries only explicitly set properties", () => {
     const sl = styles("way {color: #ff0000;}", "way", {});
     expect(Object.keys(sl.shapeStyles.default).sort()).toEqual([
       "color",
-      "edited",
       "evals"
     ]);
   });

--- a/tests/test.permalink.ts
+++ b/tests/test.permalink.ts
@@ -1,3 +1,4 @@
+import * as L from "leaflet";
 import {describe, expect, it} from "vite-plus/test";
 
 import ide from "../js/ide";
@@ -30,14 +31,15 @@ describe("ide.permalink", () => {
   });
   it("share coordinates", () => {
     const q = " ";
+    // only the two accessors compose_share_link reads
     ide.map = {
       getCenter() {
-        return {lat: 12.3456, lng: -65.4321};
+        return new L.LatLng(12.3456, -65.4321);
       },
       getZoom() {
         return 8;
       }
-    };
+    } as unknown as typeof ide.map;
     let p = ide.compose_share_link(q, false, true, false);
     expect(p).to.have.string("&C=12.3456%3B-65.4321%3B8");
     expect(p).not.to.have.string("&c=");

--- a/tests/test.popup.ts
+++ b/tests/test.popup.ts
@@ -4,7 +4,7 @@ import {featurePopupContent} from "../js/popup";
 
 describe("featurePopupContent", () => {
   it("", () => {
-    const feature = {
+    const feature: GeoJSON.Feature = {
       type: "Feature",
       id: "node/270198479",
       properties: {
@@ -33,7 +33,7 @@ describe("featurePopupContent", () => {
     expect(featurePopupContent(feature)).toMatchSnapshot();
   });
   it("", () => {
-    const feature = {
+    const feature: GeoJSON.Feature = {
       type: "Feature",
       id: "relation/1243821",
       properties: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,16 @@
 {
   "compilerOptions": {
+    "allowArbitraryExtensions": true,
     "esModuleInterop": true,
+    "lib": ["dom", "dom.iterable", "es2022"],
     "module": "esnext",
     "moduleResolution": "bundler",
+    "noEmit": true,
     "resolveJsonModule": true,
+    "skipLibCheck": true,
     "strictNullChecks": false,
-    "target": "es2022"
-  }
+    "target": "es2022",
+    "types": ["vite/client"]
+  },
+  "include": ["js", "tests", "vite.config.mts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,9 +8,17 @@
     "noEmit": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "strictNullChecks": false,
     "target": "es2022",
-    "types": ["vite/client"]
+    "types": ["vite/client"],
+
+    // Set explicitly rather than left to the compiler's default, which differs
+    // between TypeScript versions. The codebase satisfies all of `strict`
+    // except these three; turning each back on is a worthwhile piece of work on
+    // its own — noImplicitAny alone is some 275 errors.
+    "strict": true,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "strictNullChecks": false
   },
   "include": ["js", "tests", "vite.config.mts"]
 }

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -7,30 +7,28 @@ import peggy from "peggy";
 /// <reference types="vitest" />
 import {type Plugin, defineConfig, createFilter, lazyPlugins} from "vite-plus";
 
-const GIT_VERSION = JSON.stringify(
-  `${execSync("git log -1 --format=%cd --date=short", {
-    encoding: "utf-8"
-  }).trim()}/${execSync("git describe --always", {encoding: "utf-8"}).trim()}`
-);
+process.env.VITE_GIT_VERSION = `${execSync(
+  "git log -1 --format=%cd --date=short",
+  {encoding: "utf-8"}
+).trim()}/${execSync("git describe --always", {encoding: "utf-8"}).trim()}`;
 
 const dependencies = JSON.parse(
   readFileSync("package.json", {encoding: "utf-8"})
 )["dependencies"];
-const APP_DEPENDENCIES = JSON.stringify(
-  Object.keys(dependencies)
-    .map((dependency) =>
-      JSON.parse(
-        readFileSync(`node_modules/${dependency}/package.json`, {
-          encoding: "utf8"
-        })
-      )
+
+process.env.VITE_APP_DEPENDENCIES = Object.keys(dependencies)
+  .map((dependency) =>
+    JSON.parse(
+      readFileSync(`node_modules/${dependency}/package.json`, {
+        encoding: "utf8"
+      })
     )
-    .map(
-      ({name, version, license}) =>
-        `<a href="https://www.npmjs.com/package/${name}/v/${version}">${name}</a> ${version} (${license})`
-    )
-    .join(", ")
-);
+  )
+  .map(
+    ({name, version, license}) =>
+      `<a href="https://www.npmjs.com/package/${name}/v/${version}">${name}</a> ${version} (${license})`
+  )
+  .join(", ");
 
 // https://vitejs.dev/config/
 export default defineConfig(() => ({
@@ -47,10 +45,6 @@ export default defineConfig(() => ({
         resolve(__dirname, "map.html")
       ]
     }
-  },
-  define: {
-    APP_DEPENDENCIES,
-    GIT_VERSION
   },
   plugins: lazyPlugins(() => [
     inject({

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -60,6 +60,12 @@ export default defineConfig(() => ({
     environment: "happy-dom",
     include: ["tests/test*.ts"]
   },
+  lint: {
+    options: {
+      typeAware: true,
+      typeCheck: true
+    }
+  },
   fmt: {
     bracketSpacing: false,
     experimentalSortImports: {},

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -63,7 +63,7 @@ export default defineConfig(() => ({
   fmt: {
     bracketSpacing: false,
     experimentalSortImports: {},
-    trailingComma: "none",
+    trailingComma: "none" as const,
     printWidth: 80,
     ignorePatterns: ["build/", "data/", "dist/", "locales/"]
   },

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -33,9 +33,6 @@ process.env.VITE_APP_DEPENDENCIES = Object.keys(dependencies)
 // https://vitejs.dev/config/
 export default defineConfig(() => ({
   base: "./",
-  optimizeDeps: {
-    exclude: ["leaflet"]
-  },
   build: {
     sourcemap: true,
     rollupOptions: {


### PR DESCRIPTION
`tsc` reported 383 errors, and nothing ran it — `vp check` did format and lint only. This clears all of them and enables `lint.options.typeCheck`, so the Build & Deploy workflow now gates on types via the `pnpm check` step it already runs. TypeScript moves from 5.1.6 to 6, the newest release that satisfies vite-plus-core's peer range, with `strict` set explicitly rather than inherited — TypeScript 7 enables it by default and 6 does not, so leaving it unstated would quietly change what is checked on the next bump. Everything in `strict` passes except `noImplicitAny`, `noImplicitThis` and `strictNullChecks`, which stay off and are named in tsconfig.json with what each would cost.

About half the errors came from the MapCSS style parser, built on constructor functions hung off an untyped `const styleparser = {}`; it is now one ES6 class per module, pinned by new tests, since it previously had none beyond the `eval()` grammar. The subtlety worth reviewing is that style defaults must not become instance fields: `StyleChooser` told "the stylesheet set this" apart from "this is the default" by whether a property was own or inherited, so ordinary class fields would have let a later declaration overwrite an earlier one with defaults it was never asked for. That distinction is now recorded explicitly instead of inferred from object layout. A few things were deleted for being unable to work, each called out in its commit — five `*Styler` methods calling a `dojoColor` that exists nowhere, `StyleList.hasFills` calling an object as a function, and `ffs.ts`'s `get_query_clause_str` chain, which built a description of each query's clauses and threw it away. That last one looks like a comment feature that regressed rather than dead-on-arrival code, so it deserves a second opinion.